### PR TITLE
Add schema-table constants and unify ID generators

### DIFF
--- a/nest.core.infraestructura.db/Aplicacion/ModuloEntityConfig.cs
+++ b/nest.core.infraestructura.db/Aplicacion/ModuloEntityConfig.cs
@@ -8,13 +8,15 @@ namespace nest.core.infraestructura.db.Aplicacion
 {
     public class ModuloEntityConfig : IEntityTypeConfiguration<Modulo>
     {
+        public static readonly string SCHEMA = "aplicacion";
+        public static readonly string TABLE = "modulo";
         public void Configure(EntityTypeBuilder<Modulo> builder)
         {
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
                 .HasValueGenerator<ModuloValueGenerator>();
-            builder.ToTable("modulo", "aplicacion");
+            builder.ToTable(TABLE, SCHEMA);
             builder.Property(x => x.NombreCorto)
                 .HasMaxLength(9);
             builder.Property(x => x.Descripcion)
@@ -38,9 +40,7 @@ namespace nest.core.infraestructura.db.Aplicacion
     public class ModuloValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Modulo>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Modulo>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, ModuloEntityConfig.SCHEMA, ModuloEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, ModuloEntityConfig.SCHEMA, ModuloEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Audit/AuditLogEntityConfig.cs
+++ b/nest.core.infraestructura.db/Audit/AuditLogEntityConfig.cs
@@ -29,6 +29,6 @@ namespace nest.core.infraestructura.db.Audit
     {
         public override bool GeneratesTemporaryValues => false;
         public override long Next(EntityEntry entry) => GeneradorCorrelativo.GetValue(entry.Context, AuditLogEntityConfig.SCHEMA, AuditLogEntityConfig.TABLE);
-        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => await GeneradorCorrelativo.GetValueAsync(entry.Context, AuditLogEntityConfig.Schema, AuditLogEntityConfig.Table, cancellationToken);
+        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => await GeneradorCorrelativo.GetValueAsync(entry.Context, AuditLogEntityConfig.SCHEMA, AuditLogEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Audit/CorrelativoMaestroEntityConfig.cs
+++ b/nest.core.infraestructura.db/Audit/CorrelativoMaestroEntityConfig.cs
@@ -6,9 +6,11 @@ namespace nest.core.infraestructura.db.Audit
 {
     public class CorrelativoMaestroEntityConfig : IEntityTypeConfiguration<CorrelativoMaestro>
     {
+        public static readonly string SCHEMA = "audit";
+        public static readonly string TABLE = "correlativo_maestro";
         public void Configure(EntityTypeBuilder<CorrelativoMaestro> builder)
         {
-            builder.ToTable("correlativo_maestro", "audit");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => new { x.Schema, x.Table });
         }
     }

--- a/nest.core.infraestructura.db/Corporativo/EstructuraOrganizacionalEntityConfig.cs
+++ b/nest.core.infraestructura.db/Corporativo/EstructuraOrganizacionalEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Corporativo
 {
     public class EstructuraOrganizacionalEntityConfig: IEntityTypeConfiguration<EstructuraOrganizacional>
     {
+        public static readonly string SCHEMA = "organizacion";
+        public static readonly string TABLE = "estructura_organizacional";
         public void Configure(EntityTypeBuilder<EstructuraOrganizacional> builder)
         {
-            builder.ToTable("estructura_organizacional", "organizacion");
+            builder.ToTable(TABLE, SCHEMA);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
                 .HasValueGenerator<EstructuraOrganizacionalValueGenerator>();
@@ -30,9 +32,7 @@ namespace nest.core.infraestructura.db.Corporativo
     public class EstructuraOrganizacionalValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<EstructuraOrganizacional>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<EstructuraOrganizacional>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, EstructuraOrganizacionalEntityConfig.SCHEMA, EstructuraOrganizacionalEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, EstructuraOrganizacionalEntityConfig.SCHEMA, EstructuraOrganizacionalEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Corporativo/EstructuraOrganizacionalTipoEntityConfig.cs
+++ b/nest.core.infraestructura.db/Corporativo/EstructuraOrganizacionalTipoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Corporativo
 {
     public class EstructuraOrganizacionalTipoEntityConfig: IEntityTypeConfiguration<EstructuraOrganizacionalTipo>
     {
+        public static readonly string SCHEMA = "organizacion";
+        public static readonly string TABLE = "estructura_organizacional_tipo";
         public void Configure(EntityTypeBuilder<EstructuraOrganizacionalTipo> builder)
         {
-            builder.ToTable("estructura_organizacional_tipo", "organizacion");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -23,9 +25,7 @@ namespace nest.core.infraestructura.db.Corporativo
     public class EstructuraOrganizacionalTipoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<EstructuraOrganizacionalTipo>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<EstructuraOrganizacionalTipo>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, EstructuraOrganizacionalTipoEntityConfig.SCHEMA, EstructuraOrganizacionalTipoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, EstructuraOrganizacionalTipoEntityConfig.SCHEMA, EstructuraOrganizacionalTipoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Finanzas/MonedaEntityConfig.cs
+++ b/nest.core.infraestructura.db/Finanzas/MonedaEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Finanzas
 {
     public class MonedaEntityConfig : IEntityTypeConfiguration<Moneda>
     {
+        public static readonly string SCHEMA = "finanzas";
+        public static readonly string TABLE = "moneda";
         public void Configure(EntityTypeBuilder<Moneda> builder)
         {
-            builder.ToTable("moneda", "finanzas");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -39,9 +41,7 @@ namespace nest.core.infraestructura.db.Finanzas
     public class MonedaValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Moneda>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Moneda>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, MonedaEntityConfig.SCHEMA, MonedaEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, MonedaEntityConfig.SCHEMA, MonedaEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/DepartamentoEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/DepartamentoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     internal class DepartamentoEntityConfig : IEntityTypeConfiguration<Departamento>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "departamento";
         public void Configure(EntityTypeBuilder<Departamento> builder)
         {
-            builder.ToTable("departamento", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -56,9 +58,7 @@ namespace nest.core.infraestructura.db.General
     public class DepartamentoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Departamento>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Departamento>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, DepartamentoEntityConfig.SCHEMA, DepartamentoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, DepartamentoEntityConfig.SCHEMA, DepartamentoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/DistritoEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/DistritoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class DistritoEntityConfig : IEntityTypeConfiguration<Distrito>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "distrito";
         public void Configure(EntityTypeBuilder<Distrito> builder)
         {
-            builder.ToTable("distrito", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -62,9 +64,7 @@ namespace nest.core.infraestructura.db.General
     public class DistritoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Distrito>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Distrito>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, DistritoEntityConfig.SCHEMA, DistritoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, DistritoEntityConfig.SCHEMA, DistritoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/DocumentoIdentidadTipoEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/DocumentoIdentidadTipoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class DocumentoIdentidadTipoEntityConfig : IEntityTypeConfiguration<DocumentoIdentidadTipo>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "documento_identidad_tipo";
         public void Configure(EntityTypeBuilder<DocumentoIdentidadTipo> builder)
         {
-            builder.ToTable("documento_identidad_tipo", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -33,9 +35,7 @@ namespace nest.core.infraestructura.db.General
     public class DocumentoIdentidadTipoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<DocumentoIdentidadTipo>().Max(g => (byte?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<DocumentoIdentidadTipo>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, DocumentoIdentidadTipoEntityConfig.SCHEMA, DocumentoIdentidadTipoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, DocumentoIdentidadTipoEntityConfig.SCHEMA, DocumentoIdentidadTipoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/DocumentoTipoEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/DocumentoTipoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class DocumentoTipoEntityConfig : IEntityTypeConfiguration<DocumentoTipo>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "documento_tipo";
         public void Configure(EntityTypeBuilder<DocumentoTipo> builder)
         {
-            builder.ToTable("documento_tipo", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -23,9 +25,7 @@ namespace nest.core.infraestructura.db.General
     public class DocumentoTipoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<DocumentoTipo>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<DocumentoTipo>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, DocumentoTipoEntityConfig.SCHEMA, DocumentoTipoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, DocumentoTipoEntityConfig.SCHEMA, DocumentoTipoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/LicenciaConducirEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/LicenciaConducirEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class LicenciaConducirEntityConfig : IEntityTypeConfiguration<LicenciaConducir>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "licencia_conducir";
         public void Configure(EntityTypeBuilder<LicenciaConducir> builder)
         {
-            builder.ToTable("licencia_conducir", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -39,9 +41,7 @@ namespace nest.core.infraestructura.db.General
     public class LicenciaConducirValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<LicenciaConducir>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<LicenciaConducir>().MaxAsync(g => (byte?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, LicenciaConducirEntityConfig.SCHEMA, LicenciaConducirEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, LicenciaConducirEntityConfig.SCHEMA, LicenciaConducirEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/PaisEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/PaisEntityConfig.cs
@@ -8,10 +8,12 @@ namespace nest.core.infraestructura.db.General
 {
     public class PaisEntityConfig : IEntityTypeConfiguration<Pais>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "pais";
         public void Configure(EntityTypeBuilder<Pais> builder)
         {
             builder.HasKey(x => x.Id);
-            builder.ToTable("pais", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
                 .HasValueGenerator<PaisValueGenerator>();
@@ -54,9 +56,7 @@ namespace nest.core.infraestructura.db.General
     public class PaisValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Pais>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Pais>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, PaisEntityConfig.SCHEMA, PaisEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, PaisEntityConfig.SCHEMA, PaisEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/PersonaEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/PersonaEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class PersonaEntityConfig : IEntityTypeConfiguration<Persona>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "persona";
         public void Configure(EntityTypeBuilder<Persona> builder)
         {
-            builder.ToTable("persona", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -43,9 +45,7 @@ namespace nest.core.infraestructura.db.General
     public class PersonaValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Persona>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Persona>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, PersonaEntityConfig.SCHEMA, PersonaEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, PersonaEntityConfig.SCHEMA, PersonaEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/ProvinciaEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/ProvinciaEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class ProvinciaEntityConfig : IEntityTypeConfiguration<Provincia>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "provincia";
         public void Configure(EntityTypeBuilder<Provincia> builder)
         {
-            builder.ToTable("provincia", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -41,9 +43,7 @@ namespace nest.core.infraestructura.db.General
     public class ProvinciaValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Provincia>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Provincia>().MaxAsync(g => (byte?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, ProvinciaEntityConfig.SCHEMA, ProvinciaEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, ProvinciaEntityConfig.SCHEMA, ProvinciaEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/General/SexoEntityConfig.cs
+++ b/nest.core.infraestructura.db/General/SexoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.General
 {
     public class SexoEntityConfig : IEntityTypeConfiguration<Sexo>
     {
+        public static readonly string SCHEMA = "dbo";
+        public static readonly string TABLE = "sexo";
         public void Configure(EntityTypeBuilder<Sexo> builder)
         {
-            builder.ToTable("sexo", "dbo");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -32,9 +34,7 @@ namespace nest.core.infraestructura.db.General
     public class SexoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Sexo>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Sexo>().MaxAsync(g => (byte?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, SexoEntityConfig.SCHEMA, SexoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, SexoEntityConfig.SCHEMA, SexoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Legal/ContratoCabeceraEntityConfig.cs
+++ b/nest.core.infraestructura.db/Legal/ContratoCabeceraEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Legal
 {
     public class ContratoCabeceraEntityConfig : IEntityTypeConfiguration<ContratoCabecera>
     {
+        public static readonly string SCHEMA = "legal";
+        public static readonly string TABLE = "contrato_cabecera";
         public void Configure(EntityTypeBuilder<ContratoCabecera> builder)
         {
-            builder.ToTable("contrato_cabecera", "legal");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -29,9 +31,7 @@ namespace nest.core.infraestructura.db.Legal
     public class ContratoCabeceraValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<ContratoCabecera>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<ContratoCabecera>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, ContratoCabeceraEntityConfig.SCHEMA, ContratoCabeceraEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, ContratoCabeceraEntityConfig.SCHEMA, ContratoCabeceraEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Legal/ContratoDetalleEntityConfig.cs
+++ b/nest.core.infraestructura.db/Legal/ContratoDetalleEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Legal
 {
     public class ContratoDetalleEntityConfig : IEntityTypeConfiguration<ContratoDetalle>
     {
+        public static readonly string SCHEMA = "legal";
+        public static readonly string TABLE = "contrato_detalle";
         public void Configure(EntityTypeBuilder<ContratoDetalle> builder)
         {
-            builder.ToTable("contrato_detalle", "legal");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -28,9 +30,7 @@ namespace nest.core.infraestructura.db.Legal
     public class ContratoDetalleValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<ContratoDetalle>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<ContratoDetalle>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, ContratoDetalleEntityConfig.SCHEMA, ContratoDetalleEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, ContratoDetalleEntityConfig.SCHEMA, ContratoDetalleEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Legal/ContratoPersonalEntityConfig.cs
+++ b/nest.core.infraestructura.db/Legal/ContratoPersonalEntityConfig.cs
@@ -6,9 +6,11 @@ namespace nest.core.infraestructura.db.Legal
 {
     public class ContratoPersonalEntityConfig : IEntityTypeConfiguration<ContratoPersonal>
     {
+        public static readonly string SCHEMA = "legal";
+        public static readonly string TABLE = "contrato_personal";
         public void Configure(EntityTypeBuilder<ContratoPersonal> builder)
         {
-            builder.ToTable("contrato_personal", "legal");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.ContratoCabeceraId);
             builder.Property(x => x.ContratoCabeceraId)
                 .ValueGeneratedNever();

--- a/nest.core.infraestructura.db/Legal/ContratoTipoEntityConfig.cs
+++ b/nest.core.infraestructura.db/Legal/ContratoTipoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Legal
 {
     internal class ContratoTipoEntityConfig : IEntityTypeConfiguration<ContratoTipo>
     {
+        public static readonly string SCHEMA = "legal";
+        public static readonly string TABLE = "contrato_tipo";
         public void Configure(EntityTypeBuilder<ContratoTipo> builder)
         {
-            builder.ToTable("contrato_tipo", "legal");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -34,9 +36,7 @@ namespace nest.core.infraestructura.db.Legal
     public class ContratoTipoValueGenerator : ValueGenerator<byte>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override byte Next(EntityEntry entry) =>
-            (byte)((entry.Context.Set<ContratoTipo>().Max(g => (byte?)g.Id) ?? 0) + 1);
-        public override async ValueTask<byte> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (byte)((await entry.Context.Set<ContratoTipo>().MaxAsync(g => (byte?)g.Id, cancellationToken) ?? 0) + 1);
+        public override byte Next(EntityEntry entry) => (byte)GeneradorCorrelativo.GetValue(entry.Context, ContratoTipoEntityConfig.SCHEMA, ContratoTipoEntityConfig.TABLE);
+        public override async ValueTask<byte> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (byte)await GeneradorCorrelativo.GetValueAsync(entry.Context, ContratoTipoEntityConfig.SCHEMA, ContratoTipoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/AlmacenEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/AlmacenEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica
 {
     public class AlmacenEntityConfig : IEntityTypeConfiguration<Almacen>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "almacen";
         public void Configure(EntityTypeBuilder<Almacen> builder)
         {
-            builder.ToTable("almacen", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -43,9 +45,7 @@ namespace nest.core.infraestructura.db.Logistica
     public class AlmacenValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Almacen>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Almacen>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, AlmacenEntityConfig.SCHEMA, AlmacenEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, AlmacenEntityConfig.SCHEMA, AlmacenEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/LogisticaTransaccionEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/LogisticaTransaccionEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica
 {
     public class LogisticaTransaccionEntityConfig : IEntityTypeConfiguration<LogisticaTransaccion>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "logistica_transaccion";
         public void Configure(EntityTypeBuilder<LogisticaTransaccion> builder)
         {
-            builder.ToTable("logistica_transaccion", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -42,9 +44,7 @@ namespace nest.core.infraestructura.db.Logistica
     public class LogisticaTransaccionValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<LogisticaTransaccion>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<LogisticaTransaccion>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, LogisticaTransaccionEntityConfig.SCHEMA, LogisticaTransaccionEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, LogisticaTransaccionEntityConfig.SCHEMA, LogisticaTransaccionEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/ProductoEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/ProductoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica
 {
     public class ProductoEntityConfig : IEntityTypeConfiguration<Producto>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "producto";
         public void Configure(EntityTypeBuilder<Producto> builder)
         {
-            builder.ToTable("producto", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -30,9 +32,7 @@ namespace nest.core.infraestructura.db.Logistica
     public class ProductoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<Producto>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<Producto>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, ProductoEntityConfig.SCHEMA, ProductoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, ProductoEntityConfig.SCHEMA, ProductoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/ProductoLoteEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/ProductoLoteEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica
 {
     public class ProductoLoteEntityConfig : IEntityTypeConfiguration<ProductoLote>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "producto_lote";
         public void Configure(EntityTypeBuilder<ProductoLote> builder)
         {
-            builder.ToTable("producto_lote", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -24,9 +26,7 @@ namespace nest.core.infraestructura.db.Logistica
     public class ProductoLoteValueGenerator : ValueGenerator<long>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override long Next(EntityEntry entry) =>
-            (entry.Context.Set<ProductoLote>().Max(g => (long?)g.Id) ?? 0) + 1;
-        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<ProductoLote>().MaxAsync(g => (long?)g.Id, cancellationToken) ?? 0) + 1;
+        public override long Next(EntityEntry entry) => GeneradorCorrelativo.GetValue(entry.Context, ProductoLoteEntityConfig.SCHEMA, ProductoLoteEntityConfig.TABLE);
+        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => await GeneradorCorrelativo.GetValueAsync(entry.Context, ProductoLoteEntityConfig.SCHEMA, ProductoLoteEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/Transaccional/InventarioCabeceraEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/Transaccional/InventarioCabeceraEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica.Transaccional
 {
     public class InventarioCabeceraEntityConfig : IEntityTypeConfiguration<InventarioCabecera>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "inventario_cabecera";
         public void Configure(EntityTypeBuilder<InventarioCabecera> builder)
         {
-            builder.ToTable("inventario_cabecera", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -34,9 +36,7 @@ namespace nest.core.infraestructura.db.Logistica.Transaccional
     public class InventarioCabeceraValueGenerator : ValueGenerator<long>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override long Next(EntityEntry entry) =>
-            (entry.Context.Set<InventarioCabecera>().Max(g => (long?)g.Id) ?? 0) + 1;
-        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<InventarioCabecera>().MaxAsync(g => (long?)g.Id, cancellationToken) ?? 0) + 1;
+        public override long Next(EntityEntry entry) => GeneradorCorrelativo.GetValue(entry.Context, InventarioCabeceraEntityConfig.SCHEMA, InventarioCabeceraEntityConfig.TABLE);
+        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => await GeneradorCorrelativo.GetValueAsync(entry.Context, InventarioCabeceraEntityConfig.SCHEMA, InventarioCabeceraEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/Transaccional/InventarioDetalleEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/Transaccional/InventarioDetalleEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica.Transaccional
 {
     public class InventarioDetalleEntityConfig : IEntityTypeConfiguration<InventarioDetalle>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "inventario_detalle";
         public void Configure(EntityTypeBuilder<InventarioDetalle> builder)
         {
-            builder.ToTable("inventario_detalle", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -34,9 +36,7 @@ namespace nest.core.infraestructura.db.Logistica.Transaccional
     public class InventarioDetalleValueGenerator : ValueGenerator<long>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override long Next(EntityEntry entry) =>
-            (entry.Context.Set<InventarioDetalle>().Max(g => (long?)g.Id) ?? 0) + 1;
-        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<InventarioDetalle>().MaxAsync(g => (long?)g.Id, cancellationToken) ?? 0) + 1;
+        public override long Next(EntityEntry entry) => GeneradorCorrelativo.GetValue(entry.Context, InventarioDetalleEntityConfig.SCHEMA, InventarioDetalleEntityConfig.TABLE);
+        public override async ValueTask<long> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => await GeneradorCorrelativo.GetValueAsync(entry.Context, InventarioDetalleEntityConfig.SCHEMA, InventarioDetalleEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/Logistica/UnidadMedidaEntityConfig.cs
+++ b/nest.core.infraestructura.db/Logistica/UnidadMedidaEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.Logistica
 {
     public class UnidadMedidaEntityConfig : IEntityTypeConfiguration<UnidadMedida>
     {
+        public static readonly string SCHEMA = "logistica";
+        public static readonly string TABLE = "unidad_medida";
         public void Configure(EntityTypeBuilder<UnidadMedida> builder)
         {
-            builder.ToTable("unidad_medida", "logistica");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -24,9 +26,7 @@ namespace nest.core.infraestructura.db.Logistica
     public class UnidadMedidaValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<UnidadMedida>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<UnidadMedida>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, UnidadMedidaEntityConfig.SCHEMA, UnidadMedidaEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, UnidadMedidaEntityConfig.SCHEMA, UnidadMedidaEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/RRHH/CargoEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/CargoEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.RRHH
 {
     public class CargoEntityConfig : IEntityTypeConfiguration<Cargo>
     {
+        public static readonly string SCHEMA = "rrhh";
+        public static readonly string TABLE = "cargo";
         public void Configure(EntityTypeBuilder<Cargo> builder)
         {
-            builder.ToTable("cargo", "rrhh");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -33,9 +35,7 @@ namespace nest.core.infraestructura.db.RRHH
     public class CargoValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) => 
-            (entry.Context.Set<Cargo>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => 
-            (await entry.Context.Set<Cargo>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, CargoEntityConfig.SCHEMA, CargoEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, CargoEntityConfig.SCHEMA, CargoEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/RRHH/GrupoHorarioEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/GrupoHorarioEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.RRHH
 {
     public class GrupoHorarioEntityConfig : IEntityTypeConfiguration<GrupoHorario>
     {
+        public static readonly string SCHEMA = "rrhh";
+        public static readonly string TABLE = "grupo_horario";
         public void Configure(EntityTypeBuilder<GrupoHorario> builder)
         {
-            builder.ToTable("grupo_horario", "rrhh");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -23,9 +25,7 @@ namespace nest.core.infraestructura.db.RRHH
     public class GrupoHorarioValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<GrupoHorario>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<GrupoHorario>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, GrupoHorarioEntityConfig.SCHEMA, GrupoHorarioEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, GrupoHorarioEntityConfig.SCHEMA, GrupoHorarioEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/RRHH/HorarioCabeceraEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/HorarioCabeceraEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.RRHH
 {
     public class HorarioCabeceraEntityConfig : IEntityTypeConfiguration<HorarioCabecera>
     {
+        public static readonly string SCHEMA = "rrhh";
+        public static readonly string TABLE = "horario_cabecera";
         public void Configure(EntityTypeBuilder<HorarioCabecera> builder)
         {
-            builder.ToTable("horario_cabecera", "rrhh");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -20,9 +22,7 @@ namespace nest.core.infraestructura.db.RRHH
     public class HorarioCabeceraValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<HorarioCabecera>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<HorarioCabecera>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, HorarioCabeceraEntityConfig.SCHEMA, HorarioCabeceraEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, HorarioCabeceraEntityConfig.SCHEMA, HorarioCabeceraEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/RRHH/HorarioDetalleEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/HorarioDetalleEntityConfig.cs
@@ -8,9 +8,11 @@ namespace nest.core.infraestructura.db.RRHH
 {
     public class HorarioDetalleEntityConfig : IEntityTypeConfiguration<HorarioDetalle>
     {
+        public static readonly string SCHEMA = "rrhh";
+        public static readonly string TABLE = "horario_detalle";
         public void Configure(EntityTypeBuilder<HorarioDetalle> builder)
         {
-            builder.ToTable("horario_detalle", "rrhh");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever()
@@ -28,9 +30,7 @@ namespace nest.core.infraestructura.db.RRHH
     public class HorarioDetalleValueGenerator : ValueGenerator<int>
     {
         public override bool GeneratesTemporaryValues => false;
-        public override int Next(EntityEntry entry) =>
-            (entry.Context.Set<HorarioDetalle>().Max(g => (int?)g.Id) ?? 0) + 1;
-        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) =>
-            (await entry.Context.Set<HorarioDetalle>().MaxAsync(g => (int?)g.Id, cancellationToken) ?? 0) + 1;
+        public override int Next(EntityEntry entry) => (int)GeneradorCorrelativo.GetValue(entry.Context, HorarioDetalleEntityConfig.SCHEMA, HorarioDetalleEntityConfig.TABLE);
+        public override async ValueTask<int> NextAsync(EntityEntry entry, CancellationToken cancellationToken = default) => (int)await GeneradorCorrelativo.GetValueAsync(entry.Context, HorarioDetalleEntityConfig.SCHEMA, HorarioDetalleEntityConfig.TABLE, cancellationToken);
     }
 }

--- a/nest.core.infraestructura.db/RRHH/PersonalConfiguracionEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/PersonalConfiguracionEntityConfig.cs
@@ -7,9 +7,11 @@ namespace nest.core.infraestructura.db.RRHH
 {
     public class PersonalConfiguracionEntityConfig : IEntityTypeConfiguration<PersonalConfiguracion>
     {
+        public static readonly string SCHEMA = "rrhh";
+        public static readonly string TABLE = "personal_configuracion";
         public void Configure(EntityTypeBuilder<PersonalConfiguracion> builder)
         {
-            builder.ToTable("personal_configuracion", "rrhh");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever();

--- a/nest.core.infraestructura.db/RRHH/PersonalEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/PersonalEntityConfig.cs
@@ -6,9 +6,11 @@ namespace nest.core.infraestructura.db.RRHH
 {
     public class PersonalEntityConfig : IEntityTypeConfiguration<Personal>
     {
+        public static readonly string SCHEMA = "rrhh";
+        public static readonly string TABLE = "personal";
         public void Configure(EntityTypeBuilder<Personal> builder)
         {
-            builder.ToTable("personal", "rrhh");
+            builder.ToTable(TABLE, SCHEMA);
             builder.HasKey(x => x.Id);
             builder.Property(x => x.Id)
                 .ValueGeneratedNever();


### PR DESCRIPTION
## Summary
- add `SCHEMA` and `TABLE` constants to all `*EntityConfig` files in `nest.core.infraestructura.db`
- replace explicit `builder.ToTable` usage with the constants
- update value generators to use `GeneradorCorrelativo`
- keep and use existing `GeneradorCorrelativo` implementation

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841da8e7a2c8333b664fc807217172b