### PR TITLE
Add ContratoTipo projects

### DIFF
--- a/nest.core.aplicacion.legal/ConfigureServices.cs
+++ b/nest.core.aplicacion.legal/ConfigureServices.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using nest.core.aplication.auth;
+using nest.core.dominio.Legal.ContratoTipoEntities;
+using nest.core.dominio.Security.Tenant;
+using nest.core.infraestructura.legal;
+
+namespace nest.core.aplicacion.legal
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureInfraestructura(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.AddAutoMapper(typeof(infraestructura.legal.Mapper.AutomapperProfiles));
+            services.AddTransient<IConnectionStringService>((serviceProvider) => AuthClaim.constructClaimsAuth(serviceProvider, configuration));
+            services.AddTransient<IContratoTipoRepository, ContratoTipoRepository>();
+            return services;
+        }
+    }
+}

--- a/nest.core.aplicacion.legal/ContratoTipoServices/ContratoTipoService.cs
+++ b/nest.core.aplicacion.legal/ContratoTipoServices/ContratoTipoService.cs
@@ -1,0 +1,19 @@
+using nest.core.dominio.Legal.ContratoTipoEntities;
+
+namespace nest.core.aplicacion.legal.ContratoTipoServices
+{
+    public class ContratoTipoService
+    {
+        private readonly IContratoTipoRepository repository;
+        public ContratoTipoService(IContratoTipoRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<ContratoTipo> ObtenerPorId(byte id) => this.repository.ObtenerPorId(id);
+        public Task<List<ContratoTipo>> ObtenerTodos() => this.repository.ObtenerTodos();
+        public Task<ContratoTipo> Agregar(ContratoTipoCrearDto entry) => this.repository.Agregar(entry);
+        public Task<ContratoTipo> Modificar(byte id, ContratoTipoCrearDto entry) => this.repository.Modificar(id, entry);
+        public Task Eliminar(byte id) => this.repository.Eliminar(id);
+    }
+}

--- a/nest.core.aplicacion.legal/nest.core.aplicacion.legal.csproj
+++ b/nest.core.aplicacion.legal/nest.core.aplicacion.legal.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplication.auth\nest.core.aplication.auth.csproj" />
+    <ProjectReference Include="..\nest.core.dominio\nest.core.dominio.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.legal\nest.core.infraestructura.legal.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.security\nest.core.infraestructura.security.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.dominio/Legal/ContratoTipoEntities/ContratoTipoCrearDto.cs
+++ b/nest.core.dominio/Legal/ContratoTipoEntities/ContratoTipoCrearDto.cs
@@ -1,0 +1,8 @@
+namespace nest.core.dominio.Legal.ContratoTipoEntities
+{
+    public class ContratoTipoCrearDto
+    {
+        public string Nombre { get; set; }
+        public string Detalle { get; set; }
+    }
+}

--- a/nest.core.dominio/Legal/ContratoTipoEntities/IContratoTipoRepository.cs
+++ b/nest.core.dominio/Legal/ContratoTipoEntities/IContratoTipoRepository.cs
@@ -1,0 +1,11 @@
+namespace nest.core.dominio.Legal.ContratoTipoEntities
+{
+    public interface IContratoTipoRepository
+    {
+        Task<ContratoTipo> ObtenerPorId(byte id);
+        Task<List<ContratoTipo>> ObtenerTodos();
+        Task<ContratoTipo> Agregar(ContratoTipoCrearDto entidad);
+        Task<ContratoTipo> Modificar(byte id, ContratoTipoCrearDto entidad);
+        Task Eliminar(byte id);
+    }
+}

--- a/nest.core.infraestructura.legal/ContratoTipoRepository.cs
+++ b/nest.core.infraestructura.legal/ContratoTipoRepository.cs
@@ -1,0 +1,48 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Legal.ContratoTipoEntities;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.infrastructura.utils.Excepciones;
+
+namespace nest.core.infraestructura.legal
+{
+    public class ContratoTipoRepository : IContratoTipoRepository
+    {
+        private readonly NestDbContext context;
+        private readonly IMapper mapper;
+        public ContratoTipoRepository(NestDbContext context, IMapper mapper)
+        {
+            this.context = context;
+            this.mapper = mapper;
+        }
+
+        public async Task<ContratoTipo> ObtenerPorId(byte id) => await context.ContratoTipo.Where(x => x.Id == id).FirstOrDefaultAsync();
+        public async Task<List<ContratoTipo>> ObtenerTodos() => await context.ContratoTipo.ToListAsync();
+        public async Task<ContratoTipo> Agregar(ContratoTipoCrearDto entry)
+        {
+            var entity = mapper.Map<ContratoTipo>(entry);
+            context.ContratoTipo.Add(entity);
+            await context.SaveChangesAsync();
+            await context.Entry(entity).ReloadAsync();
+            return entity;
+        }
+        public async Task<ContratoTipo> Modificar(byte id, ContratoTipoCrearDto entry)
+        {
+            var existente = await context.ContratoTipo.FindAsync(id);
+            if (existente == null)
+                throw new RegistroNoEncontradoException<ContratoTipo>(id);
+            mapper.Map(entry, existente);
+            await context.SaveChangesAsync();
+            await context.Entry(existente).ReloadAsync();
+            return existente;
+        }
+        public async Task Eliminar(byte id)
+        {
+            var existente = await context.ContratoTipo.FindAsync(id);
+            if (existente == null)
+                throw new RegistroNoEncontradoException<ContratoTipo>(id);
+            context.ContratoTipo.Remove(existente);
+            context.SaveChanges();
+        }
+    }
+}

--- a/nest.core.infraestructura.legal/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.legal/Mapper/AutomapperProfiles.cs
@@ -1,0 +1,13 @@
+using AutoMapper;
+using nest.core.dominio.Legal.ContratoTipoEntities;
+
+namespace nest.core.infraestructura.legal.Mapper
+{
+    public class AutomapperProfiles : Profile
+    {
+        public AutomapperProfiles()
+        {
+            CreateMap<ContratoTipoCrearDto, ContratoTipo>();
+        }
+    }
+}

--- a/nest.core.infraestructura.legal/nest.core.infraestructura.legal.csproj
+++ b/nest.core.infraestructura.legal/nest.core.infraestructura.legal.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.dominio\nest.core.dominio.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+    <ProjectReference Include="..\nest.core.infrastructura.utils\nest.core.infrastructura.utils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.legal/Controllers/ContratoTipoController.cs
+++ b/nest.core.legal/Controllers/ContratoTipoController.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.legal.ContratoTipoServices;
+using nest.core.dominio;
+using nest.core.dominio.Legal.ContratoTipoEntities;
+
+namespace nest.core.legal.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión de tipos de contrato.
+    /// </summary>
+    [Authorize]
+    [Route("[controller]")]
+    [ApiController]
+    public class ContratoTipoController : ControllerBase
+    {
+        private readonly ContratoTipoService service;
+        private readonly ILogger<ContratoTipoController> logger;
+
+        public ContratoTipoController(ContratoTipoService service, ILogger<ContratoTipoController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todos los tipos de contrato registrados.
+        /// </summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<ContratoTipo>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<ContratoTipo>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene un tipo de contrato por su ID.
+        /// </summary>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(ContratoTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<ContratoTipo>> ObtenerPorId(byte id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Agrega un nuevo tipo de contrato.
+        /// </summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(ContratoTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<ContratoTipo>> Agregar([FromBody] ContratoTipoCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Modifica un tipo de contrato existente.
+        /// </summary>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(ContratoTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<ContratoTipo>> Modificar(byte id, [FromBody] ContratoTipoCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Elimina un tipo de contrato.
+        /// </summary>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(byte id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.legal/Extensions/ConfigureServices.cs
+++ b/nest.core.legal/Extensions/ConfigureServices.cs
@@ -1,0 +1,15 @@
+using nest.core.aplicacion.legal;
+using nest.core.aplicacion.legal.ContratoTipoServices;
+
+namespace nest.core.legal.Extensions
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureAplication(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.ConfigureInfraestructura(configuration);
+            services.AddScoped<ContratoTipoService>();
+            return services;
+        }
+    }
+}

--- a/nest.core.legal/Program.cs
+++ b/nest.core.legal/Program.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.legal.Extensions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services custom
+builder.Configuration.AddJsonFile("appsettings.json", optional: true)
+                     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                     .AddUserSecrets<Program>()
+                     .AddEnvironmentVariables();
+builder.Services.ConfigureAplication(builder.Configuration);
+builder.Services.AddDbContext<NestDbContext>();
+builder.Services.AddHealthChecks().AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", builder =>
+    {
+        builder.AllowAnyOrigin()
+               .AllowAnyMethod()
+               .AllowAnyHeader();
+    });
+});
+// End services custom
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+    }); ;
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c => {
+    string proyecto = Assembly.GetExecutingAssembly().GetName().Name.Split('.')[2];
+    proyecto = char.ToUpper(proyecto[0]) + proyecto.Substring(1).ToLower();
+    string apiName = $"{proyecto} Api";
+    c.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = apiName,
+        Version = $"v{Assembly.GetExecutingAssembly().GetName().Version}",
+        Description = $"La {apiName} permite gestionar los almacenes de la organizacin. Con esta API puedes consultar, crear, modificar y eliminar almacenes, as como obtener slo aquellos activos.\r\n\r\nTodos los endpoints requieren autorizacin para acceder.",
+        Contact = new OpenApiContact { Email = "gabogth@gmail.com", Name = "Gabriel Rodriguez", Url = new Uri("https://es.stackoverflow.com/users/30423") }
+    });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "Ingrese el token JWT en este formato: Bearer {token}",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement(){{
+        new OpenApiSecurityScheme {
+            Reference = new OpenApiReference {
+                Type = ReferenceType.SecurityScheme,
+                Id = "Bearer"
+            }
+        },
+        new string[] {} }
+    });
+    c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"));
+});
+builder.Services.AddAuthentication(option =>
+{
+    option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    option.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(option =>
+{
+    option.SaveToken = true;
+    option.TokenValidationParameters = new TokenValidationParameters
+    {
+        SaveSigninToken = true,
+        ValidateIssuer = true,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Issuer"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
+
+var app = builder.Build();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseCors("CorsPolicy");
+app.MapControllers();
+app.Run();

--- a/nest.core.legal/appsettings.Development.json
+++ b/nest.core.legal/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/nest.core.legal/appsettings.json
+++ b/nest.core.legal/appsettings.json
@@ -1,0 +1,24 @@
+{
+  "Connections": {
+    "Connection_Tenant_1": {
+      "ConnectionString": "Server=localhost;Database=nest;User Id=sa;Password=4N&XY&d_0y6+;TrustServerCertificate=true;MultipleActiveResultSets=true;Application Name=nest.core.security;",
+      "Engine": "SQLSERVER"
+    },
+    "Connection_Tenant_2": {
+      "ConnectionString": "Host=localhost;Port=5432;Database=nest;Username=postgres;Password=root",
+      "Engine": "POSTGRES"
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Jwt": {
+    "Issuer": "https://empresa.com",
+    "Audience": "https://empresa.com",
+    "Key": "ckO9z0o8ZppcIbrOsT8Nj58uKgZkJwOoNwNVLpJVPz0="
+  },
+  "AllowedHosts": "*"
+}

--- a/nest.core.legal/nest.core.legal.csproj
+++ b/nest.core.legal/nest.core.legal.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>1591</NoWarn>
+    <FileVersion></FileVersion>
+    <AssemblyVersion>1.0.0.16</AssemblyVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplicacion.legal\nest.core.aplicacion.legal.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.legal/nest.core.legal.http
+++ b/nest.core.legal/nest.core.legal.http
@@ -1,0 +1,6 @@
+@nest.core.rrhh_HostAddress = http://localhost:5117
+
+GET {{nest.core.rrhh_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/nest.sln
+++ b/nest.sln
@@ -58,6 +58,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.rrhh",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.rrhh", "nest.core.rrhh\nest.core.rrhh.csproj", "{0DD21FF4-1B7C-48B5-B118-637926543FE2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.infraestructura.legal", "nest.core.infraestructura.legal\nest.core.infraestructura.legal.csproj", "{5DEE3FE0-DED0-46D3-92F1-7D68A81F2E1A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.legal", "nest.core.aplicacion.legal\nest.core.aplicacion.legal.csproj", "{31456CD2-B2EF-46DB-AB85-C65E85598F47}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.legal", "nest.core.legal\nest.core.legal.csproj", "{560A6D30-3BE5-4385-8B6D-902F57DF51DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -135,6 +141,18 @@ Global
 		{0DD21FF4-1B7C-48B5-B118-637926543FE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0DD21FF4-1B7C-48B5-B118-637926543FE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DD21FF4-1B7C-48B5-B118-637926543FE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5DEE3FE0-DED0-46D3-92F1-7D68A81F2E1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5DEE3FE0-DED0-46D3-92F1-7D68A81F2E1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {5DEE3FE0-DED0-46D3-92F1-7D68A81F2E1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5DEE3FE0-DED0-46D3-92F1-7D68A81F2E1A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {31456CD2-B2EF-46DB-AB85-C65E85598F47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {31456CD2-B2EF-46DB-AB85-C65E85598F47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {31456CD2-B2EF-46DB-AB85-C65E85598F47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {31456CD2-B2EF-46DB-AB85-C65E85598F47}.Release|Any CPU.Build.0 = Release|Any CPU
+                {560A6D30-3BE5-4385-8B6D-902F57DF51DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {560A6D30-3BE5-4385-8B6D-902F57DF51DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {560A6D30-3BE5-4385-8B6D-902F57DF51DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {560A6D30-3BE5-4385-8B6D-902F57DF51DF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0DD21FF4-1B7C-48B5-B118-637926543FE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
@@ -159,6 +177,9 @@ Global
 		{D0E0A52B-67D0-4F86-96C8-7E680830FD8D} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
 		{C5025189-2B28-412A-A320-72F3A03E9390} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
 		{0DD21FF4-1B7C-48B5-B118-637926543FE2} = {B8494947-0BD9-4763-BC5A-40667E95E294}
+                {5DEE3FE0-DED0-46D3-92F1-7D68A81F2E1A} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
+                {31456CD2-B2EF-46DB-AB85-C65E85598F47} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
+                {560A6D30-3BE5-4385-8B6D-902F57DF51DF} = {B8494947-0BD9-4763-BC5A-40667E95E294}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {651F4B0C-740F-4ABF-8B23-D07A56743FFF}


### PR DESCRIPTION
## Summary
- add domain classes for ContratoTipo
- add application layer with service and DI registration
- add infrastructure project with repository and automapper profile
- create legal API project with controller and program configuration
- update solution file to include new projects

## Testing
- `dotnet build nest.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684228cf45f48333bd7b73f4da6fdb32