### PR TITLE
Refactor repositories using CachedRepositoryBase

### DIFF
--- a/nest.core.dominio/Aplicacion/Modulo/Modulo.cs
+++ b/nest.core.dominio/Aplicacion/Modulo/Modulo.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.Aplicacion.Modulo
 {
-    public class Modulo : IAuditable
+    public class Modulo : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/General/DocumentoIdentidadTipoEntities/DocumentoIdentidadTipo.cs
+++ b/nest.core.dominio/General/DocumentoIdentidadTipoEntities/DocumentoIdentidadTipo.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.General.DocumentoIdentidadTipoEntities
 {
-    public class DocumentoIdentidadTipo : IAuditable
+    public class DocumentoIdentidadTipo : IAuditable, IEntity<byte>
     {
         public byte Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/General/DocumentoTipoEntities/DocumentoTipo.cs
+++ b/nest.core.dominio/General/DocumentoTipoEntities/DocumentoTipo.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.General.DocumentoTipoEntities
 {
-    public class DocumentoTipo : IAuditable
+    public class DocumentoTipo : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/General/LicenciaConducirEntities/LicenciaConducir.cs
+++ b/nest.core.dominio/General/LicenciaConducirEntities/LicenciaConducir.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.General.LicenciaConducirEntities
 {
-    public class LicenciaConducir : IAuditable
+    public class LicenciaConducir : IAuditable, IEntity<byte>
     {
         public byte Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/General/PaisEntities/Pais.cs
+++ b/nest.core.dominio/General/PaisEntities/Pais.cs
@@ -1,9 +1,10 @@
-﻿using nest.core.dominio.General.DepartamentoEntites;
+using nest.core.dominio.General.DepartamentoEntites;
 using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.General.PaisEntities
 {
-    public class Pais : IAuditable
+    public class Pais : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/General/ProvinciaEntities/Provincia.cs
+++ b/nest.core.dominio/General/ProvinciaEntities/Provincia.cs
@@ -1,10 +1,11 @@
-﻿using nest.core.dominio.General.DepartamentoEntites;
+using nest.core.dominio.General.DepartamentoEntites;
 using nest.core.dominio.General.DistritoEntities;
 using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.General.ProvinciaEntities
 {
-    public class Provincia : IAuditable
+    public class Provincia : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/General/SexoEntities/Sexo.cs
+++ b/nest.core.dominio/General/SexoEntities/Sexo.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.General.SexoEntities
 {
-    public class Sexo: IAuditable
+    public class Sexo: IAuditable, IEntity<byte>
     {
         public byte Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/Legal/ContratoTipoEntities/ContratoTipo.cs
+++ b/nest.core.dominio/Legal/ContratoTipoEntities/ContratoTipo.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.Legal.ContratoTipoEntities
 {
-    public class ContratoTipo : IAuditable
+    public class ContratoTipo : IAuditable, IEntity<byte>
     {
         public byte Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/Logistica/AlmacenEN/Almacen.cs
+++ b/nest.core.dominio/Logistica/AlmacenEN/Almacen.cs
@@ -1,9 +1,10 @@
-﻿using nest.core.dominio.General.DistritoEntities;
+using nest.core.dominio.General.DistritoEntities;
 using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.Logistica.AlmacenEN
 {
-    public class Almacen : IAuditable
+    public class Almacen : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/RRHH/CargoEntities/Cargo.cs
+++ b/nest.core.dominio/RRHH/CargoEntities/Cargo.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.RRHH.CargoEntities
 {
-    public class Cargo : IAuditable
+    public class Cargo : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/RRHH/GrupoHorarioEntities/GrupoHorario.cs
+++ b/nest.core.dominio/RRHH/GrupoHorarioEntities/GrupoHorario.cs
@@ -1,8 +1,9 @@
-﻿using nest.core.dominio.Security.Audit;
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
 
 namespace nest.core.dominio.RRHH.GrupoHorarioEntities
 {
-    public class GrupoHorario : IAuditable
+    public class GrupoHorario : IAuditable, IEntity<int>
     {
         public int Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.infraestructura.general/DocumentoIdentidadTipoRepository.cs
+++ b/nest.core.infraestructura.general/DocumentoIdentidadTipoRepository.cs
@@ -1,51 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.General.DocumentoIdentidadTipoEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.general
 {
-    public class DocumentoIdentidadTipoRepository : IDocumentoIdentidadTipoRepository
+    public class DocumentoIdentidadTipoRepository : CachedRepositoryBase<DocumentoIdentidadTipo, DocumentoIdentidadTipoCrearDto, byte>, IDocumentoIdentidadTipoRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public DocumentoIdentidadTipoRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<DocumentoIdentidadTipo> ObtenerPorId(byte id) =>
-            await context.DocumentoIdentidadTipo.FirstOrDefaultAsync(x => x.Id == id);
-        public async Task<List<DocumentoIdentidadTipo>> ObtenerTodos() =>
-            await context.DocumentoIdentidadTipo.ToListAsync();
-        public async Task<List<DocumentoIdentidadTipo>> ObtenerActivos() =>
-            await context.DocumentoIdentidadTipo.ToListAsync();
-        public async Task<DocumentoIdentidadTipo> Agregar(DocumentoIdentidadTipoCrearDto entry)
-        {
-            var entidad = mapper.Map<DocumentoIdentidadTipo>(entry);
-            context.DocumentoIdentidadTipo.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
-            return entidad;
-        }
-        public async Task<DocumentoIdentidadTipo> Modificar(byte id, DocumentoIdentidadTipoCrearDto entry)
-        {
-            var existente = await context.DocumentoIdentidadTipo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<DocumentoIdentidadTipo>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(byte id)
-        {
-            var existente = await context.DocumentoIdentidadTipo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<DocumentoIdentidadTipo>(id);
-            context.DocumentoIdentidadTipo.Remove(existente);
-            context.SaveChanges();
-        }
+        public DocumentoIdentidadTipoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+        public async Task<DocumentoIdentidadTipo> ObtenerPorId(byte id) => await GetByIdAsync(id);
+        public async Task<List<DocumentoIdentidadTipo>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<DocumentoIdentidadTipo>> ObtenerActivos() => await GetAllAsync();
+        public Task<DocumentoIdentidadTipo> Agregar(DocumentoIdentidadTipoCrearDto dto) => AddAsync(dto);
+        public Task<DocumentoIdentidadTipo> Modificar(byte id, DocumentoIdentidadTipoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(byte id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.general/DocumentoTipoRepository.cs
+++ b/nest.core.infraestructura.general/DocumentoTipoRepository.cs
@@ -1,51 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.General.DocumentoTipoEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.general
 {
-    public class DocumentoTipoRepository : IDocumentoTipoRepository
+    public class DocumentoTipoRepository : CachedRepositoryBase<DocumentoTipo, DocumentoTipoCrearDto, int>, IDocumentoTipoRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public DocumentoTipoRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<DocumentoTipo> ObtenerPorId(int id) =>
-            await context.DocumentoTipo.FirstOrDefaultAsync(x => x.Id == id);
-        public async Task<List<DocumentoTipo>> ObtenerTodos() =>
-            await context.DocumentoTipo.ToListAsync();
-        public async Task<List<DocumentoTipo>> ObtenerActivos() =>
-            await context.DocumentoTipo.ToListAsync();
-        public async Task<DocumentoTipo> Agregar(DocumentoTipoCrearDto entry)
-        {
-            var entidad = mapper.Map<DocumentoTipo>(entry);
-            context.DocumentoTipo.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
-            return entidad;
-        }
-        public async Task<DocumentoTipo> Modificar(int id, DocumentoTipoCrearDto entry)
-        {
-            var existente = await context.DocumentoTipo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<DocumentoTipo>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(int id)
-        {
-            var existente = await context.DocumentoTipo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<DocumentoTipo>(id);
-            context.DocumentoTipo.Remove(existente);
-            context.SaveChanges();
-        }
+        public DocumentoTipoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+        public async Task<DocumentoTipo> ObtenerPorId(int id) => await GetByIdAsync(id);
+        public async Task<List<DocumentoTipo>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<DocumentoTipo>> ObtenerActivos() => await GetAllAsync();
+        public Task<DocumentoTipo> Agregar(DocumentoTipoCrearDto dto) => AddAsync(dto);
+        public Task<DocumentoTipo> Modificar(int id, DocumentoTipoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(int id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.general/LicenciaConducirRepository.cs
+++ b/nest.core.infraestructura.general/LicenciaConducirRepository.cs
@@ -1,51 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.General.LicenciaConducirEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.general
 {
-    public class LicenciaConducirRepository : ILicenciaConducirRepository
+    public class LicenciaConducirRepository : CachedRepositoryBase<LicenciaConducir, LicenciaConducirCrearDto, byte>, ILicenciaConducirRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public LicenciaConducirRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<LicenciaConducir> ObtenerPorId(byte id) =>
-            await context.LicenciaConducir.FirstOrDefaultAsync(x => x.Id == id);
-        public async Task<List<LicenciaConducir>> ObtenerTodos() =>
-            await context.LicenciaConducir.ToListAsync();
-        public async Task<List<LicenciaConducir>> ObtenerActivos() =>
-            await context.LicenciaConducir.ToListAsync();
-        public async Task<LicenciaConducir> Agregar(LicenciaConducirCrearDto entry)
-        {
-            var entidad = mapper.Map<LicenciaConducir>(entry);
-            context.LicenciaConducir.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
-            return entidad;
-        }
-        public async Task<LicenciaConducir> Modificar(byte id, LicenciaConducirCrearDto entry)
-        {
-            var existente = await context.LicenciaConducir.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<LicenciaConducir>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(byte id)
-        {
-            var existente = await context.LicenciaConducir.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<LicenciaConducir>(id);
-            context.LicenciaConducir.Remove(existente);
-            context.SaveChanges();
-        }
+        public LicenciaConducirRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+        public async Task<LicenciaConducir> ObtenerPorId(byte id) => await GetByIdAsync(id);
+        public async Task<List<LicenciaConducir>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<LicenciaConducir>> ObtenerActivos() => await GetAllAsync();
+        public Task<LicenciaConducir> Agregar(LicenciaConducirCrearDto dto) => AddAsync(dto);
+        public Task<LicenciaConducir> Modificar(byte id, LicenciaConducirCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(byte id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.general/PaisRepository.cs
+++ b/nest.core.infraestructura.general/PaisRepository.cs
@@ -1,51 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.General.PaisEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.general
 {
-    public class PaisRepository : IPaisRepository
+    public class PaisRepository : CachedRepositoryBase<Pais, PaisCrearDto, int>, IPaisRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public PaisRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<Pais> ObtenerPorId(int id) =>
-            await context.Pais.FirstOrDefaultAsync(x => x.Id == id);
-        public async Task<List<Pais>> ObtenerTodos() =>
-            await context.Pais.ToListAsync();
-        public async Task<List<Pais>> ObtenerActivos() =>
-            await context.Pais.ToListAsync();
-        public async Task<Pais> Agregar(PaisCrearDto entry)
-        {
-            var entidad = mapper.Map<Pais>(entry);
-            context.Pais.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
-            return entidad;
-        }
-        public async Task<Pais> Modificar(int id, PaisCrearDto entry)
-        {
-            var existente = await context.Pais.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Pais>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(int id)
-        {
-            var existente = await context.Pais.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Pais>(id);
-            context.Pais.Remove(existente);
-            context.SaveChanges();
-        }
+        public PaisRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+        public async Task<Pais> ObtenerPorId(int id) => await GetByIdAsync(id);
+        public async Task<List<Pais>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<Pais>> ObtenerActivos() => await GetAllAsync();
+        public Task<Pais> Agregar(PaisCrearDto dto) => AddAsync(dto);
+        public Task<Pais> Modificar(int id, PaisCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(int id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.general/ProvinciaRepository.cs
+++ b/nest.core.infraestructura.general/ProvinciaRepository.cs
@@ -1,51 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.General.ProvinciaEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.general
 {
-    public class ProvinciaRepository : IProvinciaRepository
+    public class ProvinciaRepository : CachedRepositoryBase<Provincia, ProvinciaCrearDto, int>, IProvinciaRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public ProvinciaRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<Provincia> ObtenerPorId(int id) =>
-            await context.Provincia.FirstOrDefaultAsync(x => x.Id == id);
-        public async Task<List<Provincia>> ObtenerTodos() =>
-            await context.Provincia.ToListAsync();
-        public async Task<List<Provincia>> ObtenerActivos() =>
-            await context.Provincia.ToListAsync();
-        public async Task<Provincia> Agregar(ProvinciaCrearDto entry)
-        {
-            var entidad = mapper.Map<Provincia>(entry);
-            context.Provincia.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
-            return entidad;
-        }
-        public async Task<Provincia> Modificar(int id, ProvinciaCrearDto entry)
-        {
-            var existente = await context.Provincia.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Provincia>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(int id)
-        {
-            var existente = await context.Provincia.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Provincia>(id);
-            context.Provincia.Remove(existente);
-            context.SaveChanges();
-        }
+        public ProvinciaRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+        public async Task<Provincia> ObtenerPorId(int id) => await GetByIdAsync(id);
+        public async Task<List<Provincia>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<Provincia>> ObtenerActivos() => await GetAllAsync();
+        public Task<Provincia> Agregar(ProvinciaCrearDto dto) => AddAsync(dto);
+        public Task<Provincia> Modificar(int id, ProvinciaCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(int id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.general/SexoRepository.cs
+++ b/nest.core.infraestructura.general/SexoRepository.cs
@@ -1,51 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.General.SexoEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.general
 {
-    public class SexoRepository : ISexoRepository
+    public class SexoRepository : CachedRepositoryBase<Sexo, SexoCrearDto, byte>, ISexoRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public SexoRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<Sexo> ObtenerPorId(byte id) =>
-            await context.Sexos.FirstOrDefaultAsync(x => x.Id == id);
-        public async Task<List<Sexo>> ObtenerTodos() =>
-            await context.Sexos.ToListAsync();
-        public async Task<List<Sexo>> ObtenerActivos() =>
-            await context.Sexos.ToListAsync();
-        public async Task<Sexo> Agregar(SexoCrearDto entry)
-        {
-            var entidad = mapper.Map<Sexo>(entry);
-            context.Sexos.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
-            return entidad;
-        }
-        public async Task<Sexo> Modificar(byte id, SexoCrearDto entry)
-        {
-            var existente = await context.Sexos.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Sexo>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(byte id)
-        {
-            var existente = await context.Sexos.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Sexo>(id);
-            context.Sexos.Remove(existente);
-            context.SaveChanges();
-        }
+        public SexoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+        public async Task<Sexo> ObtenerPorId(byte id) => await GetByIdAsync(id);
+        public async Task<List<Sexo>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<Sexo>> ObtenerActivos() => await GetAllAsync();
+        public Task<Sexo> Agregar(SexoCrearDto dto) => AddAsync(dto);
+        public Task<Sexo> Modificar(byte id, SexoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(byte id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.legal/ContratoTipoRepository.cs
+++ b/nest.core.infraestructura.legal/ContratoTipoRepository.cs
@@ -1,48 +1,19 @@
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.Legal.ContratoTipoEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.legal
 {
-    public class ContratoTipoRepository : IContratoTipoRepository
+    public class ContratoTipoRepository : CachedRepositoryBase<ContratoTipo, ContratoTipoCrearDto, byte>, IContratoTipoRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public ContratoTipoRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
+        public ContratoTipoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
 
-        public async Task<ContratoTipo> ObtenerPorId(byte id) => await context.ContratoTipo.Where(x => x.Id == id).FirstOrDefaultAsync();
-        public async Task<List<ContratoTipo>> ObtenerTodos() => await context.ContratoTipo.ToListAsync();
-        public async Task<ContratoTipo> Agregar(ContratoTipoCrearDto entry)
-        {
-            var entity = mapper.Map<ContratoTipo>(entry);
-            context.ContratoTipo.Add(entity);
-            await context.SaveChangesAsync();
-            await context.Entry(entity).ReloadAsync();
-            return entity;
-        }
-        public async Task<ContratoTipo> Modificar(byte id, ContratoTipoCrearDto entry)
-        {
-            var existente = await context.ContratoTipo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<ContratoTipo>(id);
-            mapper.Map(entry, existente);
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
-        }
-        public async Task Eliminar(byte id)
-        {
-            var existente = await context.ContratoTipo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<ContratoTipo>(id);
-            context.ContratoTipo.Remove(existente);
-            context.SaveChanges();
-        }
+        public async Task<ContratoTipo> ObtenerPorId(byte id) => await GetByIdAsync(id);
+        public async Task<List<ContratoTipo>> ObtenerTodos() => await GetAllAsync();
+        public Task<ContratoTipo> Agregar(ContratoTipoCrearDto dto) => AddAsync(dto);
+        public Task<ContratoTipo> Modificar(byte id, ContratoTipoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(byte id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.rrhh/GrupoHorarioRepository.cs
+++ b/nest.core.infraestructura.rrhh/GrupoHorarioRepository.cs
@@ -1,72 +1,37 @@
-﻿using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+using AutoMapper;
+using nest.core.dominio.Cache;
 using nest.core.dominio.RRHH.CargoEntities;
 using nest.core.dominio.RRHH.GrupoHorarioEntities;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
-using nest.core.infrastructura.utils.Excepciones;
 
 namespace nest.core.infraestructura.rrhh
 {
-    public class GrupoHorarioRepository : IGrupoHorarioRepository
+    public class GrupoHorarioRepository : CachedRepositoryBase<GrupoHorario, GrupoHorarioCrearDto, int>, IGrupoHorarioRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
+        public GrupoHorarioRepository(NestDbContext context, IMapper mapper, ICacheRepository cache)
+            : base(context, mapper, cache) { }
 
-        public GrupoHorarioRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
+        public async Task<GrupoHorario> ObtenerPorId(int id) => await GetByIdAsync(id);
 
-        public async Task<GrupoHorario> ObtenerPorId(int id)
-        {
-            return await context.GrupoHorarios
-                .Where(g => g.Id == id)
-                .FirstOrDefaultAsync();
-        }
+        public async Task<List<GrupoHorario>> ObtenerTodos() => await GetAllAsync();
 
-        public async Task<List<GrupoHorario>> ObtenerTodos()
-        {
-            return await context.GrupoHorarios
-                .ToListAsync();
-        }
-
-        public async Task<List<GrupoHorario>> ObtenerActivos()
-        {
-            // Como no hay campo "Activo", devolvemos todos los registros.
-            return await context.GrupoHorarios
-                .ToListAsync();
-        }
+        public async Task<List<GrupoHorario>> ObtenerActivos() => await GetAllAsync();
 
         public async Task<GrupoHorario> Agregar(GrupoHorarioCrearDto entry)
         {
-            var entidad = mapper.Map<GrupoHorario>(entry);
+            var entidad = await AddAsync(entry);
             entidad.FechaCreacion = DateTime.UtcNow;
-            context.GrupoHorarios.Add(entidad);
-            await context.SaveChangesAsync();
-            await context.Entry(entidad).ReloadAsync();
             return entidad;
         }
 
         public async Task<GrupoHorario> Modificar(int id, GrupoHorarioCrearDto entry)
         {
-            var existente = await context.GrupoHorarios.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<GrupoHorario>(id);
-            mapper.Map(entry, existente);
-            existente.FechaModificacion = DateTime.UtcNow;
-            await context.SaveChangesAsync();
-            await context.Entry(existente).ReloadAsync();
-            return existente;
+            var entidad = await UpdateAsync(id, entry);
+            entidad.FechaModificacion = DateTime.UtcNow;
+            return entidad;
         }
 
-        public async Task Eliminar(int id)
-        {
-            var existente = await context.GrupoHorarios.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<GrupoHorario>(id);
-            context.GrupoHorarios.Remove(existente);
-            context.SaveChanges();
-        }
+        public Task Eliminar(int id) => DeleteAsync(id);
     }
 }

--- a/nest.core.infraestructura.security/Aplicacion/FormularioRepository.cs
+++ b/nest.core.infraestructura.security/Aplicacion/FormularioRepository.cs
@@ -1,34 +1,26 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.Aplicacion.Modulo;
 using nest.core.dominio.Aplicacion.Formulario;
 using nest.core.infrastructura.utils.Excepciones;
+using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
 using nest.core.dominio.RRHH.CargoEntities;
 
 namespace nest.core.infraestructura.security.Aplicacion
 {
-    public class FormularioRepository: IFormularioRepository
+    public class FormularioRepository: CachedRepositoryBase<Formulario, FormularioCrearDto, int>, IFormularioRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public FormularioRepository(NestDbContext context, IMapper mapper)
+        public FormularioRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache)
         {
-            this.context = context;
-            this.mapper = mapper;
         }
-        public async Task<Formulario> ObtenerPorId(int id)
-        {
-            return await context.Formulario.Where(x => x.Id == id).FirstOrDefaultAsync();
-        }
+        public async Task<Formulario> ObtenerPorId(int id) => await GetByIdAsync(id);
         public async Task<List<Formulario>> ObtenerPorModuloId(int moduloId)
         {
             return await context.Formulario.AsNoTracking().Where(x => x.ModuloId == moduloId).ToListAsync();
         }
-        public async Task<List<Formulario>> ObtenerTodos()
-        {
-            return await context.Formulario.ToListAsync();
-        }
+        public async Task<List<Formulario>> ObtenerTodos() => await GetAllAsync();
         public async Task<List<Formulario>> ObtenerPorUnaPropiedad(Dictionary<string, object> filtros)
         {
             IQueryable<Formulario> query = context.Formulario;
@@ -52,30 +44,21 @@ namespace nest.core.infraestructura.security.Aplicacion
         public async Task<Formulario> Agregar(FormularioCrearDto entry)
         {
             entry.ParentId = entry.ParentId == 0 ? null : entry.ParentId;
-            Formulario entryFine = mapper.Map<Formulario>(entry);
-            await context.Formulario.AddAsync(entryFine);
-            await context.SaveChangesAsync();
-            await context.Entry(entryFine).ReloadAsync();
-            return entryFine;
+            return await AddAsync(entry);
         }
         public async Task<Formulario> Modificar(int id, FormularioCrearDto entry)
         {
-            Formulario find = await context.Formulario.FirstOrDefaultAsync(x => x.Id == id);
-            if (find == null)
-                throw new RegistroNoEncontradoException<Formulario>(id);
-            mapper.Map(entry, find);
-            find.FechaModificacion = DateTime.Now;
+            var entidad = await context.Formulario.FindAsync(id) ?? throw new RegistroNoEncontradoException<Formulario>(id);
+            mapper.Map(entry, entidad);
+            entidad.FechaModificacion = DateTime.Now;
             await context.SaveChangesAsync();
-            await context.Entry(find).ReloadAsync();
-            return find;
+            await context.Entry(entidad).ReloadAsync();
+            await InvalidateCacheAsync();
+            return entidad;
         }
         public async Task Eliminar(int id)
         {
-            var existente = await context.Formulario.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Cargo>(id);
-            context.Formulario.Remove(existente);
-            context.SaveChanges();
+            await DeleteAsync(id);
         }
     }
 }

--- a/nest.core.infraestructura.security/Aplicacion/ModuloRepository.cs
+++ b/nest.core.infraestructura.security/Aplicacion/ModuloRepository.cs
@@ -1,30 +1,21 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Cache;
 using nest.core.dominio.Aplicacion.Modulo;
 using nest.core.dominio.Aplicacion.Modulo.Repository;
 using nest.core.dominio.RRHH.CargoEntities;
-using nest.core.infraestructura.db.DbContext;
 using nest.core.infrastructura.utils.Excepciones;
+using nest.core.infraestructura.db.Cache;
+using nest.core.infraestructura.db.DbContext;
 
 namespace nest.core.infraestructura.security.Aplicacion
 {
-    public class ModuloRepository : IModuloRepository
+    public class ModuloRepository : CachedRepositoryBase<Modulo, ModuloCrearDto, int>, IModuloRepository
     {
-        private readonly NestDbContext context;
-        private readonly IMapper mapper;
-        public ModuloRepository(NestDbContext context, IMapper mapper)
-        {
-            this.context = context;
-            this.mapper = mapper;
-        }
-        public async Task<Modulo> ObtenerPorId(int id)
-        {
-            return await context.Modulo.Where(x => x.Id == id).FirstOrDefaultAsync();
-        }
-        public async Task<List<Modulo>> ObtenerTodos()
-        {
-            return await context.Modulo.ToListAsync();
-        }
+        public ModuloRepository(NestDbContext context, IMapper mapper, ICacheRepository cache)
+            : base(context, mapper, cache) { }
+        public async Task<Modulo> ObtenerPorId(int id) => await GetByIdAsync(id);
+        public async Task<List<Modulo>> ObtenerTodos() => await GetAllAsync();
         public async Task<List<Modulo>> ObtenerPorUnaPropiedad(Dictionary<string, object> filtros) 
         {
             IQueryable<Modulo> query = context.Modulo;
@@ -40,32 +31,17 @@ namespace nest.core.infraestructura.security.Aplicacion
             }
             return await query.ToListAsync();
         }
-        public async Task<Modulo> Agregar(ModuloCrearDto entry)
-        {
-            Modulo entryFine = mapper.Map<Modulo>(entry);
-            await context.Modulo.AddAsync(entryFine);
-            await context.SaveChangesAsync();
-            await context.Entry(entryFine).ReloadAsync();
-            return entryFine;
-        }
+        public async Task<Modulo> Agregar(ModuloCrearDto entry) => await AddAsync(entry);
         public async Task<Modulo> Modificar(int id, ModuloCrearDto entry)
         {
-            var find = await context.Modulo.FirstOrDefaultAsync(x => x.Id == id);
-            if (find == null)
-                throw new RegistroNoEncontradoException<Modulo>(id);
-            Modulo entryFine = mapper.Map<Modulo>(entry);
-            entryFine.FechaModificacion = DateTime.Now;
+            var entidad = await context.Modulo.FindAsync(id) ?? throw new RegistroNoEncontradoException<Modulo>(id);
+            mapper.Map(entry, entidad);
+            entidad.FechaModificacion = DateTime.Now;
             await context.SaveChangesAsync();
-            await context.Entry(entryFine).ReloadAsync();
-            return entryFine;
+            await context.Entry(entidad).ReloadAsync();
+            await InvalidateCacheAsync();
+            return entidad;
         }
-        public async Task Eliminar(int id)
-        {
-            var existente = await context.Modulo.FindAsync(id);
-            if (existente == null)
-                throw new RegistroNoEncontradoException<Cargo>(id);
-            context.Modulo.Remove(existente);
-            context.SaveChanges();
-        }
+        public async Task Eliminar(int id) => await DeleteAsync(id);
     }
 }


### PR DESCRIPTION
## Summary
- implement `IEntity<TKey>` on multiple domain entities
- refactor listed repositories to extend `CachedRepositoryBase`
- simplify CRUD operations using shared repository logic

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adf94768c8333b5196068f542150c