### PR TITLE
Add PersonalEstado entity and its layers

### DIFF
--- a/nest.core.aplicacion.rrhh/ConfigureServices.cs
+++ b/nest.core.aplicacion.rrhh/ConfigureServices.cs
@@ -4,6 +4,7 @@ using nest.core.aplication.auth;
 using nest.core.dominio.RRHH.CargoEntities;
 using nest.core.dominio.RRHH.GrupoHorarioEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
+using nest.core.dominio.RRHH.PersonalEstadoEntities;
 using nest.core.dominio.Security.Tenant;
 using nest.core.infraestructura.rrhh;
 
@@ -18,6 +19,7 @@ namespace nest.core.aplicacion.rrhh
             services.AddTransient<ICargoRepository, CargoRepository>();
             services.AddTransient<IGrupoHorarioRepository, GrupoHorarioRepository>();
             services.AddTransient<IPersonalRepository, PersonalRepository>();
+            services.AddTransient<IPersonalEstadoRepository, PersonalEstadoRepository>();
             return services;
         }
     }

--- a/nest.core.aplicacion.rrhh/PersonalEstadoServices/PersonalEstadoService.cs
+++ b/nest.core.aplicacion.rrhh/PersonalEstadoServices/PersonalEstadoService.cs
@@ -1,0 +1,19 @@
+using nest.core.dominio.RRHH.PersonalEstadoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalEstadoServices
+{
+    public class PersonalEstadoService
+    {
+        private readonly IPersonalEstadoRepository repository;
+        public PersonalEstadoService(IPersonalEstadoRepository repository)
+        {
+            this.repository = repository;
+        }
+        public Task<PersonalEstado> ObtenerPorId(byte id) => repository.ObtenerPorId(id);
+        public Task<List<PersonalEstado>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<List<PersonalEstado>> ObtenerActivos() => repository.ObtenerActivos();
+        public Task<PersonalEstado> Agregar(PersonalEstadoCrearDto entry) => repository.Agregar(entry);
+        public Task<PersonalEstado> Modificar(byte id, PersonalEstadoCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(byte id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.dominio/RRHH/PersonalEstadoEntities/IPersonalEstadoRepository.cs
+++ b/nest.core.dominio/RRHH/PersonalEstadoEntities/IPersonalEstadoRepository.cs
@@ -1,0 +1,12 @@
+namespace nest.core.dominio.RRHH.PersonalEstadoEntities
+{
+    public interface IPersonalEstadoRepository
+    {
+        Task<PersonalEstado> ObtenerPorId(byte id);
+        Task<List<PersonalEstado>> ObtenerTodos();
+        Task<List<PersonalEstado>> ObtenerActivos();
+        Task<PersonalEstado> Agregar(PersonalEstadoCrearDto entidad);
+        Task<PersonalEstado> Modificar(byte id, PersonalEstadoCrearDto entidad);
+        Task Eliminar(byte id);
+    }
+}

--- a/nest.core.dominio/RRHH/PersonalEstadoEntities/PersonalEstado.cs
+++ b/nest.core.dominio/RRHH/PersonalEstadoEntities/PersonalEstado.cs
@@ -1,6 +1,9 @@
-﻿namespace nest.core.dominio.RRHH.PersonalEstadoEntities
+using nest.core.dominio.Security.Audit;
+using nest.core.dominio;
+
+namespace nest.core.dominio.RRHH.PersonalEstadoEntities
 {
-    public class PersonalEstado
+    public class PersonalEstado : IAuditable, IEntity<byte>
     {
         public byte Id { get; set; }
         public string Nombre { get; set; }

--- a/nest.core.dominio/RRHH/PersonalEstadoEntities/PersonalEstadoCrearDto.cs
+++ b/nest.core.dominio/RRHH/PersonalEstadoEntities/PersonalEstadoCrearDto.cs
@@ -1,0 +1,7 @@
+namespace nest.core.dominio.RRHH.PersonalEstadoEntities
+{
+    public class PersonalEstadoCrearDto
+    {
+        public string Nombre { get; set; }
+    }
+}

--- a/nest.core.infraestructura.rrhh/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.rrhh/Mapper/AutomapperProfiles.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using nest.core.dominio.RRHH.CargoEntities;
 using nest.core.dominio.RRHH.GrupoHorarioEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
+using nest.core.dominio.RRHH.PersonalEstadoEntities;
 
 namespace nest.core.infraestructura.rrhh.Mapper
 {
@@ -12,6 +13,7 @@ namespace nest.core.infraestructura.rrhh.Mapper
             CreateMap<CargoCrearDto, Cargo>();
             CreateMap<GrupoHorarioCrearDto, GrupoHorario>();
             CreateMap<PersonalCrearDto, Personal>();
+            CreateMap<PersonalEstadoCrearDto, PersonalEstado>();
         }
     }
 }

--- a/nest.core.infraestructura.rrhh/PersonalEstadoRepository.cs
+++ b/nest.core.infraestructura.rrhh/PersonalEstadoRepository.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using nest.core.dominio.Cache;
+using nest.core.dominio.RRHH.PersonalEstadoEntities;
+using nest.core.infraestructura.db.Cache;
+using nest.core.infraestructura.db.DbContext;
+
+namespace nest.core.infraestructura.rrhh
+{
+    public class PersonalEstadoRepository : CachedRepositoryBase<PersonalEstado, PersonalEstadoCrearDto, byte>, IPersonalEstadoRepository
+    {
+        public PersonalEstadoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+
+        public async Task<PersonalEstado> ObtenerPorId(byte id) => await GetByIdAsync(id);
+        public async Task<List<PersonalEstado>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<PersonalEstado>> ObtenerActivos() => await GetAllAsync();
+        public Task<PersonalEstado> Agregar(PersonalEstadoCrearDto dto) => AddAsync(dto);
+        public Task<PersonalEstado> Modificar(byte id, PersonalEstadoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(byte id) => DeleteAsync(id);
+    }
+}

--- a/nest.core.rrhh/Controllers/PersonalEstadoController.cs
+++ b/nest.core.rrhh/Controllers/PersonalEstadoController.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.rrhh.PersonalEstadoServices;
+using nest.core.dominio;
+using nest.core.dominio.RRHH.PersonalEstadoEntities;
+
+namespace nest.core.rrhh.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class PersonalEstadoController : ControllerBase
+    {
+        private readonly PersonalEstadoService service;
+        private readonly ILogger<PersonalEstadoController> logger;
+        public PersonalEstadoController(PersonalEstadoService service, ILogger<PersonalEstadoController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+        [HttpGet]
+        [ProducesResponseType(typeof(List<PersonalEstado>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<PersonalEstado>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(PersonalEstado), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<PersonalEstado>> ObtenerPorId(byte id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+        [HttpGet("activos")]
+        [ProducesResponseType(typeof(List<PersonalEstado>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<PersonalEstado>>> ObtenerActivos()
+        {
+            try
+            {
+                var data = await service.ObtenerActivos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+        [HttpPost]
+        [ProducesResponseType(typeof(PersonalEstado), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<PersonalEstado>> Agregar([FromBody] PersonalEstadoCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(PersonalEstado), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<PersonalEstado>> Modificar(byte id, [FromBody] PersonalEstadoCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(byte id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.rrhh/Extensions/ConfigureServices.cs
+++ b/nest.core.rrhh/Extensions/ConfigureServices.cs
@@ -1,6 +1,7 @@
 ﻿using nest.core.aplicacion.rrhh;
 using nest.core.aplicacion.rrhh.CargoServices;
 using nest.core.aplicacion.rrhh.GrupoHorarioServices;
+using nest.core.aplicacion.rrhh.PersonalEstadoServices;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
 
@@ -14,6 +15,7 @@ namespace nest.core.rrhh.Extensions
             services.ConfigureInfraestructura(configuration);
             services.AddScoped<CargoService>();
             services.AddScoped<GrupoHorarioService>();
+            services.AddScoped<PersonalEstadoService>();
             return services;
         }
 


### PR DESCRIPTION
## Summary
- add domain models and repository interface for `PersonalEstado`
- implement repository inheriting from `CachedRepositoryBase`
- map `PersonalEstado` DTOs in AutoMapper profiles
- add service and controller for `PersonalEstado`
- register new repository and service in DI configuration
- update existing entity to implement required interfaces

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503a8877e8833382ca4d3d50d7a504