### PR TITLE
Implement Financiero cabecera-detalle

### DIFF
--- a/nest.core.aplicacion.finanzas/ConfigureServices.cs
+++ b/nest.core.aplicacion.finanzas/ConfigureServices.cs
@@ -7,6 +7,7 @@ using nest.core.dominio.Finanzas.MonedaEntities;
 using nest.core.dominio.Finanzas.OrigenFinancieroEntities;
 using nest.core.dominio.Finanzas.PuntoFinancieroEntities;
 using nest.core.dominio.Finanzas.ClienteEntities;
+using nest.core.dominio.Finanzas.FinancieroCabeceraEntities;
 using nest.core.dominio.Security.Tenant;
 using nest.core.infraestructura.finanzas;
 
@@ -24,6 +25,7 @@ namespace nest.core.aplicacion.finanzas
             services.AddTransient<IOrigenFinancieroRepository, OrigenFinancieroRepository>();
             services.AddTransient<IPuntoFinancieroRepository, PuntoFinancieroRepository>();
             services.AddTransient<ITerceroRepository, TerceroRepository>();
+            services.AddTransient<IFinancieroRepository, FinancieroRepository>();
             return services;
         }
     }

--- a/nest.core.aplicacion.finanzas/FinancieroServices/FinancieroService.cs
+++ b/nest.core.aplicacion.finanzas/FinancieroServices/FinancieroService.cs
@@ -1,0 +1,18 @@
+using nest.core.dominio.Finanzas.FinancieroCabeceraEntities;
+
+namespace nest.core.aplicacion.finanzas.FinancieroServices
+{
+    public class FinancieroService
+    {
+        private readonly IFinancieroRepository repository;
+        public FinancieroService(IFinancieroRepository repository)
+        {
+            this.repository = repository;
+        }
+        public Task<FinancieroCabecera> ObtenerPorId(long id) => repository.ObtenerPorId(id);
+        public Task<List<FinancieroCabecera>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<FinancieroCabecera> Agregar(FinancieroDto entry) => repository.Agregar(entry);
+        public Task<FinancieroCabecera> Modificar(long id, FinancieroDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(long id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.dominio/Finanzas/FinancieroCabeceraEntities/FinancieroCabeceraCrearDto.cs
+++ b/nest.core.dominio/Finanzas/FinancieroCabeceraEntities/FinancieroCabeceraCrearDto.cs
@@ -1,0 +1,15 @@
+namespace nest.core.dominio.Finanzas.FinancieroCabeceraEntities
+{
+    public class FinancieroCabeceraCrearDto
+    {
+        public int PuntoFinancieroId { get; set; }
+        public int Numero { get; set; }
+        public OrigenFinancieroEnum OrigenFinancieroId { get; set; }
+        public EstadoFinancieroEnum Estado { get; set; }
+        public string Comentarios { get; set; }
+        public int TerceroGenId { get; set; }
+        public int DocumentoTipoGenId { get; set; }
+        public string SerieDocumentoGen { get; set; }
+        public string NumeroDocumentoGen { get; set; }
+    }
+}

--- a/nest.core.dominio/Finanzas/FinancieroCabeceraEntities/FinancieroDto.cs
+++ b/nest.core.dominio/Finanzas/FinancieroCabeceraEntities/FinancieroDto.cs
@@ -1,0 +1,10 @@
+using nest.core.dominio.Finanzas.FinancieroDetalleEntities;
+
+namespace nest.core.dominio.Finanzas.FinancieroCabeceraEntities
+{
+    public class FinancieroDto
+    {
+        public FinancieroCabeceraCrearDto Cabecera { get; set; }
+        public List<FinancieroDetalleCrearDto> Detalles { get; set; } = new();
+    }
+}

--- a/nest.core.dominio/Finanzas/FinancieroCabeceraEntities/IFinancieroRepository.cs
+++ b/nest.core.dominio/Finanzas/FinancieroCabeceraEntities/IFinancieroRepository.cs
@@ -1,0 +1,11 @@
+namespace nest.core.dominio.Finanzas.FinancieroCabeceraEntities
+{
+    public interface IFinancieroRepository
+    {
+        Task<FinancieroCabecera> ObtenerPorId(long id);
+        Task<List<FinancieroCabecera>> ObtenerTodos();
+        Task<FinancieroCabecera> Agregar(FinancieroDto entidad);
+        Task<FinancieroCabecera> Modificar(long id, FinancieroDto entidad);
+        Task Eliminar(long id);
+    }
+}

--- a/nest.core.dominio/Finanzas/FinancieroDetalleEntities/FinancieroDetalleCrearDto.cs
+++ b/nest.core.dominio/Finanzas/FinancieroDetalleEntities/FinancieroDetalleCrearDto.cs
@@ -1,0 +1,18 @@
+namespace nest.core.dominio.Finanzas.FinancieroDetalleEntities
+{
+    public class FinancieroDetalleCrearDto
+    {
+        public short Item { get; set; }
+        public int TerceroId { get; set; }
+        public DateTime FechaEmision { get; set; }
+        public DateTime FechaVencimiento { get; set; }
+        public DateTime FechaPago { get; set; }
+        public int DocumentoTipoId { get; set; }
+        public string SerieDocumento { get; set; }
+        public string NumeroDocumento { get; set; }
+        public string Concepto { get; set; }
+        public decimal Monto { get; set; }
+        public int? CuentaCorrienteId { get; set; }
+        public string ES { get; set; }
+    }
+}

--- a/nest.core.finanzas/Controllers/FinancieroController.cs
+++ b/nest.core.finanzas/Controllers/FinancieroController.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.finanzas.FinancieroServices;
+using nest.core.dominio;
+using nest.core.dominio.Finanzas.FinancieroCabeceraEntities;
+
+namespace nest.core.finanzas.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión financiera de cabeceras y detalles.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class FinancieroController : ControllerBase
+    {
+        private readonly FinancieroService service;
+        private readonly ILogger<FinancieroController> logger;
+
+        public FinancieroController(FinancieroService service, ILogger<FinancieroController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todas las cabeceras financieras.
+        /// </summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<FinancieroCabecera>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<FinancieroCabecera>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene una cabecera financiera por su Id.
+        /// </summary>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(FinancieroCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<FinancieroCabecera>> ObtenerPorId(long id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Crea una nueva cabecera financiera con sus detalles.
+        /// </summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(FinancieroCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<FinancieroCabecera>> Agregar([FromBody] FinancieroDto registro)
+        {
+            try
+            {
+                var data = await service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Modifica una cabecera financiera existente.
+        /// </summary>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(FinancieroCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<FinancieroCabecera>> Modificar(long id, [FromBody] FinancieroDto registro)
+        {
+            try
+            {
+                var data = await service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Elimina una cabecera financiera.
+        /// </summary>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(long id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.finanzas/Extensions/ConfigureServices.cs
+++ b/nest.core.finanzas/Extensions/ConfigureServices.cs
@@ -5,6 +5,7 @@ using nest.core.aplicacion.finanzas.MonedaServices;
 using nest.core.aplicacion.finanzas.OrigenFinancieroServices;
 using nest.core.aplicacion.finanzas.PuntoFinancieroServices;
 using nest.core.aplicacion.finanzas.TerceroServices;
+using nest.core.aplicacion.finanzas.FinancieroServices;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
 
@@ -22,6 +23,7 @@ namespace nest.core.finanzas.Extensions
             services.AddScoped<OrigenFinancieroService>();
             services.AddScoped<PuntoFinancieroService>();
             services.AddScoped<TerceroService>();
+            services.AddScoped<FinancieroService>();
             return services;
         }
         private static void ConfigureCache(IServiceCollection services, IConfigurationManager configuration)

--- a/nest.core.infraestructura.finanzas/FinancieroRepository.cs
+++ b/nest.core.infraestructura.finanzas/FinancieroRepository.cs
@@ -1,0 +1,119 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Finanzas.FinancieroCabeceraEntities;
+using nest.core.dominio.Finanzas.FinancieroDetalleEntities;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.infraestructura.db.Utils;
+using nest.core.infrastructura.utils.Excepciones;
+
+namespace nest.core.infraestructura.finanzas
+{
+    public class FinancieroRepository : CrudRepositoryBase<FinancieroCabecera, FinancieroDto, long>, IFinancieroRepository
+    {
+        public FinancieroRepository(NestDbContext context, IMapper mapper) : base(context, mapper) { }
+
+        protected override IQueryable<FinancieroCabecera> Query() => context.Set<FinancieroCabecera>()
+            .AsNoTracking()
+            .Include(c => c.FinancieroDetalles);
+
+        public Task<FinancieroCabecera> ObtenerPorId(long id) => GetByIdAsync(id);
+        public Task<List<FinancieroCabecera>> ObtenerTodos() => GetAllAsync();
+
+        public async Task<FinancieroCabecera> Agregar(FinancieroDto entry)
+        {
+            using var transaction = await context.Database.BeginTransactionAsync();
+            try
+            {
+                var cabecera = mapper.Map<FinancieroCabecera>(entry.Cabecera);
+                context.FinancieroCabecera.Add(cabecera);
+                await context.SaveChangesAsync();
+                await context.Entry(cabecera).ReloadAsync();
+
+                foreach (var detalleDto in entry.Detalles)
+                {
+                    var detalle = mapper.Map<FinancieroDetalle>(detalleDto);
+                    detalle.FinancieroCabeceraId = cabecera.Id;
+                    context.FinancieroDetalle.Add(detalle);
+                }
+                await context.SaveChangesAsync();
+                await transaction.CommitAsync();
+                return await GetByIdAsync(cabecera.Id);
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        }
+
+        public async Task<FinancieroCabecera> Modificar(long id, FinancieroDto entry)
+        {
+            using var transaction = await context.Database.BeginTransactionAsync();
+            try
+            {
+                var cabecera = await context.FinancieroCabecera
+                    .Include(c => c.FinancieroDetalles)
+                    .FirstOrDefaultAsync(c => c.Id == id)
+                    ?? throw new RegistroNoEncontradoException<FinancieroCabecera>(id.ToString());
+
+                mapper.Map(entry.Cabecera, cabecera);
+                var detalleDb = cabecera.FinancieroDetalles.ToDictionary(x => x.Item);
+                var insert = entry.Detalles.Where(d => !detalleDb.ContainsKey(d.Item));
+                var update = entry.Detalles.Where(d => detalleDb.ContainsKey(d.Item));
+                var delete = cabecera.FinancieroDetalles.Where(db => !entry.Detalles.Any(d => d.Item == db.Item)).ToList();
+
+                foreach (var detalleDto in insert)
+                {
+                    var detalle = mapper.Map<FinancieroDetalle>(detalleDto);
+                    detalle.FinancieroCabeceraId = cabecera.Id;
+                    context.FinancieroDetalle.Add(detalle);
+                }
+
+                foreach (var detalleDto in update)
+                {
+                    var detalle = detalleDb[detalleDto.Item];
+                    if (await TieneExtension(detalle.Id))
+                        throw new Exception($"El detalle {detalle.Item} no puede modificarse por tener extensiones");
+                    mapper.Map(detalleDto, detalle);
+                }
+
+                foreach (var detalle in delete)
+                {
+                    if (await TieneExtension(detalle.Id))
+                        throw new Exception($"El detalle {detalle.Item} no puede eliminarse por tener extensiones");
+                    context.FinancieroDetalle.Remove(detalle);
+                }
+
+                await context.SaveChangesAsync();
+                await transaction.CommitAsync();
+                return await GetByIdAsync(cabecera.Id);
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        }
+
+        public async Task Eliminar(long id)
+        {
+            var cabecera = await context.FinancieroCabecera
+                .Include(c => c.FinancieroDetalles)
+                .FirstOrDefaultAsync(c => c.Id == id)
+                ?? throw new RegistroNoEncontradoException<FinancieroCabecera>(id.ToString());
+
+            foreach (var detalle in cabecera.FinancieroDetalles)
+                if (await TieneExtension(detalle.Id))
+                    throw new Exception($"No se puede eliminar la cabecera; el detalle {detalle.Item} tiene extensiones");
+
+            context.FinancieroCabecera.Remove(cabecera);
+            await context.SaveChangesAsync();
+        }
+
+        private async Task<bool> TieneExtension(long detalleId)
+        {
+            return await context.FinancieroLogistica.AnyAsync(x => x.FinancieroDetalleId == detalleId)
+                || await context.FinancieroOrdenServicio.AnyAsync(x => x.FinancieroDetalleId == detalleId);
+        }
+    }
+}

--- a/nest.core.infraestructura.finanzas/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.finanzas/Mapper/AutomapperProfiles.cs
@@ -5,6 +5,8 @@ using nest.core.dominio.Finanzas.MonedaEntities;
 using nest.core.dominio.Finanzas.OrigenFinancieroEntities;
 using nest.core.dominio.Finanzas.PuntoFinancieroEntities;
 using nest.core.dominio.Finanzas.ClienteEntities;
+using nest.core.dominio.Finanzas.FinancieroCabeceraEntities;
+using nest.core.dominio.Finanzas.FinancieroDetalleEntities;
 
 namespace nest.core.infraestructura.finanzas.Mapper
 {
@@ -18,6 +20,8 @@ namespace nest.core.infraestructura.finanzas.Mapper
             CreateMap<OrigenFinancieroCrearDto, OrigenFinanciero>();
             CreateMap<PuntoFinancieroCrearDto, PuntoFinanciero>();
             CreateMap<TerceroCrearDto, Tercero>();
+            CreateMap<FinancieroCabeceraCrearDto, FinancieroCabecera>();
+            CreateMap<FinancieroDetalleCrearDto, FinancieroDetalle>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add DTOs and repository interface for FinancieroCabecera/Detalle
- implement FinancieroService and repository using cabecera-detalle pattern
- expose new FinancieroController
- register repository and service in DI containers
- extend AutoMapper profiles

## Testing
- `dotnet build` *(failed: `dotnet` not found)*
- `apt-get update` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687edb653a6083338bcde34cd298d648