### PR TITLE
feat: add Mantto maintenance entities with caching

### DIFF
--- a/nest.core.aplicacion.mantto/ConfigureServices.cs
+++ b/nest.core.aplicacion.mantto/ConfigureServices.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using nest.core.aplication.auth;
+using nest.core.dominio.Mantto.LaborEntities;
+using nest.core.dominio.Mantto.MantenimientoTipoEntities;
+using nest.core.dominio.Mantto.OrdenServicioTipoEntities;
+using nest.core.dominio.Security.Tenant;
+using nest.core.infraestructura.mantto;
+
+namespace nest.core.aplicacion.mantto
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureInfraestructura(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.AddAutoMapper(typeof(infraestructura.mantto.Mapper.AutomapperProfiles));
+            services.AddTransient<IConnectionStringService>((serviceProvider) => AuthClaim.constructClaimsAuth(serviceProvider, configuration));
+            services.AddTransient<ILaborRepository, LaborRepository>();
+            services.AddTransient<IMantenimientoTipoRepository, MantenimientoTipoRepository>();
+            services.AddTransient<IOrdenServicioTipoRepository, OrdenServicioTipoRepository>();
+            return services;
+        }
+    }
+}

--- a/nest.core.aplicacion.mantto/LaborServices/LaborService.cs
+++ b/nest.core.aplicacion.mantto/LaborServices/LaborService.cs
@@ -1,0 +1,20 @@
+using nest.core.dominio.Mantto.LaborEntities;
+
+namespace nest.core.aplicacion.mantto.LaborServices
+{
+    public class LaborService
+    {
+        private readonly ILaborRepository repository;
+        public LaborService(ILaborRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<Labor> ObtenerPorId(int id) => repository.ObtenerPorId(id);
+        public Task<List<Labor>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<List<Labor>> ObtenerActivos() => repository.ObtenerActivos();
+        public Task<Labor> Agregar(LaborCrearDto entry) => repository.Agregar(entry);
+        public Task<Labor> Modificar(int id, LaborCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(int id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.aplicacion.mantto/MantenimientoTipoServices/MantenimientoTipoService.cs
+++ b/nest.core.aplicacion.mantto/MantenimientoTipoServices/MantenimientoTipoService.cs
@@ -1,0 +1,20 @@
+using nest.core.dominio.Mantto.MantenimientoTipoEntities;
+
+namespace nest.core.aplicacion.mantto.MantenimientoTipoServices
+{
+    public class MantenimientoTipoService
+    {
+        private readonly IMantenimientoTipoRepository repository;
+        public MantenimientoTipoService(IMantenimientoTipoRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<MantenimientoTipo> ObtenerPorId(short id) => repository.ObtenerPorId(id);
+        public Task<List<MantenimientoTipo>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<List<MantenimientoTipo>> ObtenerActivos() => repository.ObtenerActivos();
+        public Task<MantenimientoTipo> Agregar(MantenimientoTipoCrearDto entry) => repository.Agregar(entry);
+        public Task<MantenimientoTipo> Modificar(short id, MantenimientoTipoCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(short id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.aplicacion.mantto/OrdenServicioTipoServices/OrdenServicioTipoService.cs
+++ b/nest.core.aplicacion.mantto/OrdenServicioTipoServices/OrdenServicioTipoService.cs
@@ -1,0 +1,20 @@
+using nest.core.dominio.Mantto.OrdenServicioTipoEntities;
+
+namespace nest.core.aplicacion.mantto.OrdenServicioTipoServices
+{
+    public class OrdenServicioTipoService
+    {
+        private readonly IOrdenServicioTipoRepository repository;
+        public OrdenServicioTipoService(IOrdenServicioTipoRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<OrdenServicioTipo> ObtenerPorId(short id) => repository.ObtenerPorId(id);
+        public Task<List<OrdenServicioTipo>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<List<OrdenServicioTipo>> ObtenerActivos() => repository.ObtenerActivos();
+        public Task<OrdenServicioTipo> Agregar(OrdenServicioTipoCrearDto entry) => repository.Agregar(entry);
+        public Task<OrdenServicioTipo> Modificar(short id, OrdenServicioTipoCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(short id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.aplicacion.mantto/nest.core.aplicacion.mantto.csproj
+++ b/nest.core.aplicacion.mantto/nest.core.aplicacion.mantto.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplication.auth\nest.core.aplication.auth.csproj" />
+    <ProjectReference Include="..\nest.core.dominio\nest.core.dominio.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.mantto\nest.core.infraestructura.mantto.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.security\nest.core.infraestructura.security.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.dominio/Mantto/LaborEntities/ILaborRepository.cs
+++ b/nest.core.dominio/Mantto/LaborEntities/ILaborRepository.cs
@@ -1,0 +1,12 @@
+namespace nest.core.dominio.Mantto.LaborEntities
+{
+    public interface ILaborRepository
+    {
+        Task<Labor> ObtenerPorId(int id);
+        Task<List<Labor>> ObtenerTodos();
+        Task<List<Labor>> ObtenerActivos();
+        Task<Labor> Agregar(LaborCrearDto entry);
+        Task<Labor> Modificar(int id, LaborCrearDto entry);
+        Task Eliminar(int id);
+    }
+}

--- a/nest.core.dominio/Mantto/LaborEntities/LaborCrearDto.cs
+++ b/nest.core.dominio/Mantto/LaborEntities/LaborCrearDto.cs
@@ -1,0 +1,9 @@
+namespace nest.core.dominio.Mantto.LaborEntities
+{
+    public class LaborCrearDto
+    {
+        public string Nombre { get; set; }
+        public string NombreCorto { get; set; }
+        public bool Activo { get; set; }
+    }
+}

--- a/nest.core.dominio/Mantto/MantenimientoTipoEntities/IMantenimientoTipoRepository.cs
+++ b/nest.core.dominio/Mantto/MantenimientoTipoEntities/IMantenimientoTipoRepository.cs
@@ -1,0 +1,12 @@
+namespace nest.core.dominio.Mantto.MantenimientoTipoEntities
+{
+    public interface IMantenimientoTipoRepository
+    {
+        Task<MantenimientoTipo> ObtenerPorId(short id);
+        Task<List<MantenimientoTipo>> ObtenerTodos();
+        Task<List<MantenimientoTipo>> ObtenerActivos();
+        Task<MantenimientoTipo> Agregar(MantenimientoTipoCrearDto entry);
+        Task<MantenimientoTipo> Modificar(short id, MantenimientoTipoCrearDto entry);
+        Task Eliminar(short id);
+    }
+}

--- a/nest.core.dominio/Mantto/MantenimientoTipoEntities/MantenimientoTipoCrearDto.cs
+++ b/nest.core.dominio/Mantto/MantenimientoTipoEntities/MantenimientoTipoCrearDto.cs
@@ -1,0 +1,9 @@
+namespace nest.core.dominio.Mantto.MantenimientoTipoEntities
+{
+    public class MantenimientoTipoCrearDto
+    {
+        public string Nombre { get; set; }
+        public string NombreCorto { get; set; }
+        public bool Activo { get; set; }
+    }
+}

--- a/nest.core.dominio/Mantto/OrdenServicioTipoEntities/IOrdenServicioTipoRepository.cs
+++ b/nest.core.dominio/Mantto/OrdenServicioTipoEntities/IOrdenServicioTipoRepository.cs
@@ -1,0 +1,12 @@
+namespace nest.core.dominio.Mantto.OrdenServicioTipoEntities
+{
+    public interface IOrdenServicioTipoRepository
+    {
+        Task<OrdenServicioTipo> ObtenerPorId(short id);
+        Task<List<OrdenServicioTipo>> ObtenerTodos();
+        Task<List<OrdenServicioTipo>> ObtenerActivos();
+        Task<OrdenServicioTipo> Agregar(OrdenServicioTipoCrearDto entry);
+        Task<OrdenServicioTipo> Modificar(short id, OrdenServicioTipoCrearDto entry);
+        Task Eliminar(short id);
+    }
+}

--- a/nest.core.dominio/Mantto/OrdenServicioTipoEntities/OrdenServicioTipoCrearDto.cs
+++ b/nest.core.dominio/Mantto/OrdenServicioTipoEntities/OrdenServicioTipoCrearDto.cs
@@ -1,0 +1,9 @@
+namespace nest.core.dominio.Mantto.OrdenServicioTipoEntities
+{
+    public class OrdenServicioTipoCrearDto
+    {
+        public string Nombre { get; set; }
+        public string NombreCorto { get; set; }
+        public bool Estado { get; set; }
+    }
+}

--- a/nest.core.infraestructura.mantto/LaborRepository.cs
+++ b/nest.core.infraestructura.mantto/LaborRepository.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using nest.core.dominio.Cache;
+using nest.core.dominio.Mantto.LaborEntities;
+using nest.core.infraestructura.db.Cache;
+using nest.core.infraestructura.db.DbContext;
+
+namespace nest.core.infraestructura.mantto
+{
+    public class LaborRepository : CachedRepositoryBase<Labor, LaborCrearDto, int>, ILaborRepository
+    {
+        public LaborRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+
+        public async Task<Labor> ObtenerPorId(int id) => await GetByIdAsync(id);
+        public async Task<List<Labor>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<Labor>> ObtenerActivos() => (await GetCachedListAsync()).Where(x => x.Activo).ToList();
+        public Task<Labor> Agregar(LaborCrearDto dto) => AddAsync(dto);
+        public Task<Labor> Modificar(int id, LaborCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(int id) => DeleteAsync(id);
+    }
+}

--- a/nest.core.infraestructura.mantto/MantenimientoTipoRepository.cs
+++ b/nest.core.infraestructura.mantto/MantenimientoTipoRepository.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using nest.core.dominio.Cache;
+using nest.core.dominio.Mantto.MantenimientoTipoEntities;
+using nest.core.infraestructura.db.Cache;
+using nest.core.infraestructura.db.DbContext;
+
+namespace nest.core.infraestructura.mantto
+{
+    public class MantenimientoTipoRepository : CachedRepositoryBase<MantenimientoTipo, MantenimientoTipoCrearDto, short>, IMantenimientoTipoRepository
+    {
+        public MantenimientoTipoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+
+        public async Task<MantenimientoTipo> ObtenerPorId(short id) => await GetByIdAsync(id);
+        public async Task<List<MantenimientoTipo>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<MantenimientoTipo>> ObtenerActivos() => (await GetCachedListAsync()).Where(x => x.Activo).ToList();
+        public Task<MantenimientoTipo> Agregar(MantenimientoTipoCrearDto dto) => AddAsync(dto);
+        public Task<MantenimientoTipo> Modificar(short id, MantenimientoTipoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(short id) => DeleteAsync(id);
+    }
+}

--- a/nest.core.infraestructura.mantto/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.mantto/Mapper/AutomapperProfiles.cs
@@ -1,0 +1,17 @@
+using AutoMapper;
+using nest.core.dominio.Mantto.LaborEntities;
+using nest.core.dominio.Mantto.MantenimientoTipoEntities;
+using nest.core.dominio.Mantto.OrdenServicioTipoEntities;
+
+namespace nest.core.infraestructura.mantto.Mapper
+{
+    public class AutomapperProfiles : Profile
+    {
+        public AutomapperProfiles()
+        {
+            CreateMap<LaborCrearDto, Labor>();
+            CreateMap<MantenimientoTipoCrearDto, MantenimientoTipo>();
+            CreateMap<OrdenServicioTipoCrearDto, OrdenServicioTipo>();
+        }
+    }
+}

--- a/nest.core.infraestructura.mantto/OrdenServicioTipoRepository.cs
+++ b/nest.core.infraestructura.mantto/OrdenServicioTipoRepository.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using nest.core.dominio.Cache;
+using nest.core.dominio.Mantto.OrdenServicioTipoEntities;
+using nest.core.infraestructura.db.Cache;
+using nest.core.infraestructura.db.DbContext;
+
+namespace nest.core.infraestructura.mantto
+{
+    public class OrdenServicioTipoRepository : CachedRepositoryBase<OrdenServicioTipo, OrdenServicioTipoCrearDto, short>, IOrdenServicioTipoRepository
+    {
+        public OrdenServicioTipoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
+
+        public async Task<OrdenServicioTipo> ObtenerPorId(short id) => await GetByIdAsync(id);
+        public async Task<List<OrdenServicioTipo>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<OrdenServicioTipo>> ObtenerActivos() => (await GetCachedListAsync()).Where(x => x.Estado).ToList();
+        public Task<OrdenServicioTipo> Agregar(OrdenServicioTipoCrearDto dto) => AddAsync(dto);
+        public Task<OrdenServicioTipo> Modificar(short id, OrdenServicioTipoCrearDto dto) => UpdateAsync(id, dto);
+        public Task Eliminar(short id) => DeleteAsync(id);
+    }
+}

--- a/nest.core.infraestructura.mantto/nest.core.infraestructura.mantto.csproj
+++ b/nest.core.infraestructura.mantto/nest.core.infraestructura.mantto.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+    <ProjectReference Include="..\nest.core.infrastructura.utils\nest.core.infrastructura.utils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.mantto/Controllers/LaborController.cs
+++ b/nest.core.mantto/Controllers/LaborController.cs
@@ -1,0 +1,176 @@
+using Microsoft.AspNetCore.Mvc;
+using nest.core.dominio;
+using nest.core.dominio.Mantto.LaborEntities;
+using Microsoft.AspNetCore.Authorization;
+using nest.core.aplicacion.mantto.LaborServices;
+
+namespace nest.core.mantto.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión de labores de mantenimiento.
+    /// Permite realizar operaciones CRUD y obtener labores activas.
+    /// Requiere autorización para acceder.
+    /// </summary>
+    [Authorize]
+    [Route("[controller]")]
+    [ApiController]
+    public class LaborController : ControllerBase
+    {
+        private readonly LaborService service;
+        private readonly ILogger<LaborController> logger;
+
+        /// <summary>
+        /// Constructor del controlador LaborController.
+        /// </summary>
+        /// <param name="service">Servicio para gestionar las labores.</param>
+        /// <param name="logger">Logger para registrar eventos y errores.</param>
+        public LaborController(LaborService service, ILogger<LaborController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todas las labores registradas.
+        /// </summary>
+        /// <returns>Lista de labores.</returns>
+        /// <response code="200">Devuelve la lista de labores.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<Labor>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<Labor>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await this.service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene una labor por su ID.
+        /// </summary>
+        /// <param name="id">ID de la labor.</param>
+        /// <returns>Labor correspondiente al ID.</returns>
+        /// <response code="200">Labor encontrada.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(Labor), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<Labor>> ObtenerPorId(int id)
+        {
+            try
+            {
+                var data = await this.service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene todas las labores activas.
+        /// </summary>
+        /// <returns>Lista de labores activas.</returns>
+        /// <response code="200">Devuelve la lista de labores activas.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("activos")]
+        [ProducesResponseType(typeof(List<Labor>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<Labor>>> ObtenerActivos()
+        {
+            try
+            {
+                var data = await this.service.ObtenerActivos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Agrega una nueva labor.
+        /// </summary>
+        /// <param name="registro">DTO con la información de la labor a crear.</param>
+        /// <returns>Labor creada.</returns>
+        /// <response code="200">Labor agregada exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(Labor), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<Labor>> Agregar([FromBody] LaborCrearDto registro)
+        {
+            try
+            {
+                var data = await this.service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Modifica una labor existente.
+        /// </summary>
+        /// <param name="id">ID de la labor a modificar.</param>
+        /// <param name="registro">DTO con la información actualizada de la labor.</param>
+        /// <returns>Labor modificada.</returns>
+        /// <response code="200">Labor modificada exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(Labor), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<Labor>> Modificar(int id, [FromBody] LaborCrearDto registro)
+        {
+            try
+            {
+                var data = await this.service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Elimina una labor.
+        /// </summary>
+        /// <param name="id">ID de la labor a eliminar.</param>
+        /// <returns>True si la eliminación fue exitosa.</returns>
+        /// <response code="200">Labor eliminada exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(int id)
+        {
+            try
+            {
+                await this.service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.mantto/Controllers/MantenimientoTipoController.cs
+++ b/nest.core.mantto/Controllers/MantenimientoTipoController.cs
@@ -1,0 +1,176 @@
+using Microsoft.AspNetCore.Mvc;
+using nest.core.dominio;
+using nest.core.dominio.Mantto.MantenimientoTipoEntities;
+using Microsoft.AspNetCore.Authorization;
+using nest.core.aplicacion.mantto.MantenimientoTipoServices;
+
+namespace nest.core.mantto.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión de tipos de mantenimiento.
+    /// Permite realizar operaciones CRUD y obtener registros activos.
+    /// Requiere autorización para acceder.
+    /// </summary>
+    [Authorize]
+    [Route("[controller]")]
+    [ApiController]
+    public class MantenimientoTipoController : ControllerBase
+    {
+        private readonly MantenimientoTipoService service;
+        private readonly ILogger<MantenimientoTipoController> logger;
+
+        /// <summary>
+        /// Constructor del controlador MantenimientoTipoController.
+        /// </summary>
+        /// <param name="service">Servicio para gestionar tipos de mantenimiento.</param>
+        /// <param name="logger">Logger para registrar eventos y errores.</param>
+        public MantenimientoTipoController(MantenimientoTipoService service, ILogger<MantenimientoTipoController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todos los tipos de mantenimiento registrados.
+        /// </summary>
+        /// <returns>Lista de tipos de mantenimiento.</returns>
+        /// <response code="200">Devuelve la lista de tipos de mantenimiento.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<MantenimientoTipo>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<MantenimientoTipo>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await this.service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene un tipo de mantenimiento por su ID.
+        /// </summary>
+        /// <param name="id">ID del tipo de mantenimiento.</param>
+        /// <returns>Tipo de mantenimiento correspondiente al ID.</returns>
+        /// <response code="200">Tipo de mantenimiento encontrado.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(MantenimientoTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<MantenimientoTipo>> ObtenerPorId(short id)
+        {
+            try
+            {
+                var data = await this.service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene todos los tipos de mantenimiento activos.
+        /// </summary>
+        /// <returns>Lista de tipos de mantenimiento activos.</returns>
+        /// <response code="200">Devuelve la lista de tipos de mantenimiento activos.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("activos")]
+        [ProducesResponseType(typeof(List<MantenimientoTipo>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<MantenimientoTipo>>> ObtenerActivos()
+        {
+            try
+            {
+                var data = await this.service.ObtenerActivos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Agrega un nuevo tipo de mantenimiento.
+        /// </summary>
+        /// <param name="registro">DTO con la información del tipo de mantenimiento a crear.</param>
+        /// <returns>Tipo de mantenimiento creado.</returns>
+        /// <response code="200">Tipo de mantenimiento agregado exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(MantenimientoTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<MantenimientoTipo>> Agregar([FromBody] MantenimientoTipoCrearDto registro)
+        {
+            try
+            {
+                var data = await this.service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Modifica un tipo de mantenimiento existente.
+        /// </summary>
+        /// <param name="id">ID del tipo de mantenimiento a modificar.</param>
+        /// <param name="registro">DTO con la información actualizada del tipo de mantenimiento.</param>
+        /// <returns>Tipo de mantenimiento modificado.</returns>
+        /// <response code="200">Tipo de mantenimiento modificado exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(MantenimientoTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<MantenimientoTipo>> Modificar(short id, [FromBody] MantenimientoTipoCrearDto registro)
+        {
+            try
+            {
+                var data = await this.service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Elimina un tipo de mantenimiento.
+        /// </summary>
+        /// <param name="id">ID del tipo de mantenimiento a eliminar.</param>
+        /// <returns>True si la eliminación fue exitosa.</returns>
+        /// <response code="200">Tipo de mantenimiento eliminado exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(short id)
+        {
+            try
+            {
+                await this.service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.mantto/Controllers/OrdenServicioTipoController.cs
+++ b/nest.core.mantto/Controllers/OrdenServicioTipoController.cs
@@ -1,0 +1,176 @@
+using Microsoft.AspNetCore.Mvc;
+using nest.core.dominio;
+using nest.core.dominio.Mantto.OrdenServicioTipoEntities;
+using Microsoft.AspNetCore.Authorization;
+using nest.core.aplicacion.mantto.OrdenServicioTipoServices;
+
+namespace nest.core.mantto.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión de tipos de orden de servicio.
+    /// Permite realizar operaciones CRUD y obtener registros activos.
+    /// Requiere autorización para acceder.
+    /// </summary>
+    [Authorize]
+    [Route("[controller]")]
+    [ApiController]
+    public class OrdenServicioTipoController : ControllerBase
+    {
+        private readonly OrdenServicioTipoService service;
+        private readonly ILogger<OrdenServicioTipoController> logger;
+
+        /// <summary>
+        /// Constructor del controlador OrdenServicioTipoController.
+        /// </summary>
+        /// <param name="service">Servicio para gestionar tipos de orden de servicio.</param>
+        /// <param name="logger">Logger para registrar eventos y errores.</param>
+        public OrdenServicioTipoController(OrdenServicioTipoService service, ILogger<OrdenServicioTipoController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todos los tipos de orden de servicio registrados.
+        /// </summary>
+        /// <returns>Lista de tipos de orden de servicio.</returns>
+        /// <response code="200">Devuelve la lista de tipos de orden de servicio.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<OrdenServicioTipo>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<OrdenServicioTipo>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await this.service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene un tipo de orden de servicio por su ID.
+        /// </summary>
+        /// <param name="id">ID del tipo de orden de servicio.</param>
+        /// <returns>Tipo de orden de servicio correspondiente al ID.</returns>
+        /// <response code="200">Tipo de orden de servicio encontrado.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(OrdenServicioTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioTipo>> ObtenerPorId(short id)
+        {
+            try
+            {
+                var data = await this.service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene todos los tipos de orden de servicio activos.
+        /// </summary>
+        /// <returns>Lista de tipos de orden de servicio activos.</returns>
+        /// <response code="200">Devuelve la lista de tipos de orden de servicio activos.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("activos")]
+        [ProducesResponseType(typeof(List<OrdenServicioTipo>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<OrdenServicioTipo>>> ObtenerActivos()
+        {
+            try
+            {
+                var data = await this.service.ObtenerActivos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Agrega un nuevo tipo de orden de servicio.
+        /// </summary>
+        /// <param name="registro">DTO con la información del tipo de orden de servicio a crear.</param>
+        /// <returns>Tipo de orden de servicio creado.</returns>
+        /// <response code="200">Tipo de orden de servicio agregado exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(OrdenServicioTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioTipo>> Agregar([FromBody] OrdenServicioTipoCrearDto registro)
+        {
+            try
+            {
+                var data = await this.service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Modifica un tipo de orden de servicio existente.
+        /// </summary>
+        /// <param name="id">ID del tipo de orden de servicio a modificar.</param>
+        /// <param name="registro">DTO con la información actualizada del tipo de orden de servicio.</param>
+        /// <returns>Tipo de orden de servicio modificado.</returns>
+        /// <response code="200">Tipo de orden de servicio modificado exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(OrdenServicioTipo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioTipo>> Modificar(short id, [FromBody] OrdenServicioTipoCrearDto registro)
+        {
+            try
+            {
+                var data = await this.service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Elimina un tipo de orden de servicio.
+        /// </summary>
+        /// <param name="id">ID del tipo de orden de servicio a eliminar.</param>
+        /// <returns>True si la eliminación fue exitosa.</returns>
+        /// <response code="200">Tipo de orden de servicio eliminado exitosamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(short id)
+        {
+            try
+            {
+                await this.service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.mantto/Extensions/ConfigureServices.cs
+++ b/nest.core.mantto/Extensions/ConfigureServices.cs
@@ -1,0 +1,40 @@
+using nest.core.aplicacion.mantto;
+using nest.core.aplicacion.mantto.LaborServices;
+using nest.core.aplicacion.mantto.MantenimientoTipoServices;
+using nest.core.aplicacion.mantto.OrdenServicioTipoServices;
+using nest.core.dominio.Cache;
+using nest.core.infraestructura.db.Cache;
+
+namespace nest.core.mantto.Extensions
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureAplication(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            ConfigureCache(services, configuration);
+            services.ConfigureInfraestructura(configuration);
+            services.AddScoped<LaborService>();
+            services.AddScoped<MantenimientoTipoService>();
+            services.AddScoped<OrdenServicioTipoService>();
+            return services;
+        }
+        private static void ConfigureCache(IServiceCollection services, IConfigurationManager configuration)
+        {
+            bool useRedis = configuration.GetValue<bool>($"RedisConfig:Enabled");
+            if (useRedis)
+            {
+                services.AddStackExchangeRedisCache(options =>
+                {
+                    options.Configuration = configuration.GetValue<string>($"RedisConfig:ConnectionString");
+                    options.InstanceName = configuration.GetValue<string>($"RedisConfig:InstanceName");
+                });
+                services.AddScoped<ICacheRepository, RedisCacheRepository>();
+            }
+            else
+            {
+                services.AddMemoryCache();
+                services.AddScoped<ICacheRepository, MemoryCacheRepository>();
+            }
+        }
+    }
+}

--- a/nest.core.mantto/Program.cs
+++ b/nest.core.mantto/Program.cs
@@ -1,0 +1,102 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.mantto.Extensions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services custom
+builder.Configuration.AddJsonFile("appsettings.json", optional: true)
+                     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                     .AddUserSecrets<Program>()
+                     .AddEnvironmentVariables();
+builder.Services.ConfigureAplication(builder.Configuration);
+builder.Services.AddDbContext<NestDbContext>();
+builder.Services.AddHealthChecks().AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", builder =>
+    {
+        builder.AllowAnyOrigin()
+               .AllowAnyMethod()
+               .AllowAnyHeader();
+    });
+});
+// End services custom
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+    });
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c => {
+    string proyecto = Assembly.GetExecutingAssembly().GetName().Name.Split('.')[2];
+    proyecto = char.ToUpper(proyecto[0]) + proyecto.Substring(1).ToLower();
+    string apiName = $"{proyecto} Api";
+    c.SwaggerDoc("v1", new OpenApiInfo {
+        Title = apiName,
+        Version = $"v{Assembly.GetExecutingAssembly().GetName().Version}",
+        Description = $"La {apiName} permite gestionar las entidades de mantenimiento.",
+        Contact = new OpenApiContact { Email = "gabogth@gmail.com", Name = "Gabriel Rodriguez", Url = new Uri("https://es.stackoverflow.com/users/30423") }
+    });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "Ingrese el token JWT en este formato: Bearer {token}",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer",
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement(){{
+        new OpenApiSecurityScheme {
+            Reference = new OpenApiReference {
+                Type = ReferenceType.SecurityScheme,
+                Id = "Bearer"
+            }
+        },
+        new string[] {} }
+    });
+    c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"));
+});
+builder.Services.AddAuthentication(option =>
+{
+    option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    option.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(option =>
+{
+    option.SaveToken = true;
+    option.TokenValidationParameters = new TokenValidationParameters
+    {
+        SaveSigninToken = true,
+        ValidateIssuer = true,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Issuer"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
+
+var app = builder.Build();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseCors("CorsPolicy");
+app.MapControllers();
+app.Run();

--- a/nest.core.mantto/appsettings.Development.json
+++ b/nest.core.mantto/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/nest.core.mantto/appsettings.json
+++ b/nest.core.mantto/appsettings.json
@@ -1,0 +1,33 @@
+{
+  "Connections": {
+    "Connection_Tenant_1": {
+      "ConnectionString": "Server=localhost;Database=nest;User Id=sa;Password=4N&XY&d_0y6+;TrustServerCertificate=true;MultipleActiveResultSets=true;Application Name=Nest;",
+      "Engine": "SqlServer"
+    },
+    "Connection_Tenant_2": {
+      "ConnectionString": "Host=localhost;Port=5431;Database=nest;Username=postgres;Password=4N&XY&d_0y6+;Application Name=Nest;",
+      "Engine": "Npgsql"
+    },
+    "Connection_Tenant_3": {
+      "ConnectionString": "server=localhost;port=3305;database=nest;uid=root;pwd=mysql;Application Name=Nest;",
+      "Engine": "MySql"
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Jwt": {
+    "Issuer": "https://empresa.com",
+    "Audience": "https://empresa.com",
+    "Key": "ckO9z0o8ZppcIbrOsT8Nj58uKgZkJwOoNwNVLpJVPz0="
+  },
+  "RedisConfig": {
+    "Enabled": false,
+    "ConnectionString": "localhost:6379",
+    "InstanceName": "Nest_"
+  },
+  "AllowedHosts": "*"
+}

--- a/nest.core.mantto/nest.core.mantto.csproj
+++ b/nest.core.mantto/nest.core.mantto.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplicacion.mantto\nest.core.aplicacion.mantto.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.sln
+++ b/nest.sln
@@ -87,6 +87,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.contabilidad", "nest.core.aplicacion.contabilidad\nest.core.aplicacion.contabilidad.csproj", "{DF338E11-EE26-4B9E-9A94-D43921677BF0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.contabilidad", "nest.core.contabilidad\nest.core.contabilidad.csproj", "{BAC84888-4510-4C02-AAF1-EA40D4160D84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nest.core.mantto", "nest.core.mantto\nest.core.mantto.csproj", "{2D797AE8-F294-4E40-B7F4-BBCF99B1E4F9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nest.core.aplicacion.mantto", "nest.core.aplicacion.mantto\nest.core.aplicacion.mantto.csproj", "{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nest.core.infraestructura.mantto", "nest.core.infraestructura.mantto\nest.core.infraestructura.mantto.csproj", "{873AD771-2522-4EF4-9927-1A917681ECD9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -159,6 +164,12 @@ Global
 		{DF338E11-EE26-4B9E-9A94-D43921677BF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BAC84888-4510-4C02-AAF1-EA40D4160D84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BAC84888-4510-4C02-AAF1-EA40D4160D84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+			{2D797AE8-F294-4E40-B7F4-BBCF99B1E4F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+			{2D797AE8-F294-4E40-B7F4-BBCF99B1E4F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+			{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+			{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+			{873AD771-2522-4EF4-9927-1A917681ECD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+			{873AD771-2522-4EF4-9927-1A917681ECD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -197,6 +208,9 @@ Global
 		{CF9DF34A-D63A-4DFD-93FF-138FBECA041E} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
 		{DF338E11-EE26-4B9E-9A94-D43921677BF0} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
 		{BAC84888-4510-4C02-AAF1-EA40D4160D84} = {B8494947-0BD9-4763-BC5A-40667E95E294}
+			{2D797AE8-F294-4E40-B7F4-BBCF99B1E4F9} = {B8494947-0BD9-4763-BC5A-40667E95E294}
+			{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
+			{873AD771-2522-4EF4-9927-1A917681ECD9} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {651F4B0C-740F-4ABF-8B23-D07A56743FFF}


### PR DESCRIPTION
## Summary
- add DTOs and repository interfaces for Labor, MantenimientoTipo and OrdenServicioTipo
- implement Mantto application services and infrastructure repositories with cache support
- expose new Mantto controllers and project with swagger documentation

## Testing
- `dotnet build nest.core.mantto/nest.core.mantto.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc44af705483338ce57805f80fca55