### PR TITLE
feat: add orden servicio maintenance modules

### DIFF
--- a/nest.core.aplicacion.logistica/ConfigureServices.cs
+++ b/nest.core.aplicacion.logistica/ConfigureServices.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using nest.core.aplication.auth;
 using nest.core.dominio.Logistica.AlmacenEN;
+using nest.core.dominio.Logistica.OrdenServicio;
 using nest.core.dominio.Security.Tenant;
 using nest.core.infraestructura.logistica;
 
@@ -14,6 +15,8 @@ namespace nest.core.aplicacion.logistica
             services.AddAutoMapper(typeof(infraestructura.logistica.Mapper.AutomapperProfiles));
             services.AddTransient<IConnectionStringService>((serviceProvider) => AuthClaim.constructClaimsAuth(serviceProvider, configuration));
             services.AddTransient<IAlmacenRepository, AlmacenRepository>();
+            services.AddTransient<IOrdenServicioCabeceraRepository, OrdenServicioCabeceraRepository>();
+            services.AddTransient<IOrdenServicioMantenimientoExternoRepository, OrdenServicioMantenimientoExternoRepository>();
             return services;
         }
     }

--- a/nest.core.aplicacion.logistica/OrdenServicioCabeceraService.cs
+++ b/nest.core.aplicacion.logistica/OrdenServicioCabeceraService.cs
@@ -1,0 +1,19 @@
+using nest.core.dominio.Logistica.OrdenServicio;
+
+namespace nest.core.aplicacion.logistica
+{
+    public class OrdenServicioCabeceraService
+    {
+        private readonly IOrdenServicioCabeceraRepository repository;
+        public OrdenServicioCabeceraService(IOrdenServicioCabeceraRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<OrdenServicioCabecera> ObtenerPorId(int id) => repository.ObtenerPorId(id);
+        public Task<List<OrdenServicioCabecera>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<OrdenServicioCabecera> Agregar(OrdenServicioCabeceraCrearDto entry) => repository.Agregar(entry);
+        public Task<OrdenServicioCabecera> Modificar(int id, OrdenServicioCabeceraCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(int id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.aplicacion.logistica/OrdenServicioMantenimientoExternoService.cs
+++ b/nest.core.aplicacion.logistica/OrdenServicioMantenimientoExternoService.cs
@@ -1,0 +1,19 @@
+using nest.core.dominio.Logistica.OrdenServicio;
+
+namespace nest.core.aplicacion.logistica
+{
+    public class OrdenServicioMantenimientoExternoService
+    {
+        private readonly IOrdenServicioMantenimientoExternoRepository repository;
+        public OrdenServicioMantenimientoExternoService(IOrdenServicioMantenimientoExternoRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<OrdenServicioCabecera> ObtenerPorId(int id) => repository.ObtenerPorId(id);
+        public Task<List<OrdenServicioCabecera>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<OrdenServicioMantenimientoExterno> Agregar(OrdenServicioMantenimientoExternoCrearDto entry) => repository.Agregar(entry);
+        public Task<OrdenServicioCabecera> Modificar(int id, OrdenServicioMantenimientoExternoCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(int id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.dominio/Logistica/OrdenServicio/IOrdenServicioCabeceraRepository.cs
+++ b/nest.core.dominio/Logistica/OrdenServicio/IOrdenServicioCabeceraRepository.cs
@@ -1,0 +1,11 @@
+namespace nest.core.dominio.Logistica.OrdenServicio
+{
+    public interface IOrdenServicioCabeceraRepository
+    {
+        Task<OrdenServicioCabecera> ObtenerPorId(int id);
+        Task<List<OrdenServicioCabecera>> ObtenerTodos();
+        Task<OrdenServicioCabecera> Agregar(OrdenServicioCabeceraCrearDto entry);
+        Task<OrdenServicioCabecera> Modificar(int id, OrdenServicioCabeceraCrearDto entry);
+        Task Eliminar(int id);
+    }
+}

--- a/nest.core.dominio/Logistica/OrdenServicio/IOrdenServicioMantenimientoExternoRepository.cs
+++ b/nest.core.dominio/Logistica/OrdenServicio/IOrdenServicioMantenimientoExternoRepository.cs
@@ -1,0 +1,11 @@
+namespace nest.core.dominio.Logistica.OrdenServicio
+{
+    public interface IOrdenServicioMantenimientoExternoRepository
+    {
+        Task<OrdenServicioCabecera> ObtenerPorId(int id);
+        Task<List<OrdenServicioCabecera>> ObtenerTodos();
+        Task<OrdenServicioMantenimientoExterno> Agregar(OrdenServicioMantenimientoExternoCrearDto entry);
+        Task<OrdenServicioCabecera> Modificar(int id, OrdenServicioMantenimientoExternoCrearDto entry);
+        Task Eliminar(int id);
+    }
+}

--- a/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioCabecera.cs
+++ b/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioCabecera.cs
@@ -1,0 +1,9 @@
+namespace nest.core.dominio.Logistica.OrdenServicio
+{
+    public class OrdenServicioCabecera
+    {
+        public int Id { get; set; }
+        public DateTime Fecha { get; set; }
+        public string Numero { get; set; } = string.Empty;
+    }
+}

--- a/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioCabeceraCrearDto.cs
+++ b/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioCabeceraCrearDto.cs
@@ -1,0 +1,8 @@
+namespace nest.core.dominio.Logistica.OrdenServicio
+{
+    public class OrdenServicioCabeceraCrearDto
+    {
+        public DateTime Fecha { get; set; }
+        public string Numero { get; set; } = string.Empty;
+    }
+}

--- a/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioMantenimientoExterno.cs
+++ b/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioMantenimientoExterno.cs
@@ -1,0 +1,8 @@
+namespace nest.core.dominio.Logistica.OrdenServicio
+{
+    public class OrdenServicioMantenimientoExterno : OrdenServicioCabecera
+    {
+        public string Proveedor { get; set; } = string.Empty;
+        public decimal Costo { get; set; }
+    }
+}

--- a/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioMantenimientoExternoCrearDto.cs
+++ b/nest.core.dominio/Logistica/OrdenServicio/OrdenServicioMantenimientoExternoCrearDto.cs
@@ -1,0 +1,8 @@
+namespace nest.core.dominio.Logistica.OrdenServicio
+{
+    public class OrdenServicioMantenimientoExternoCrearDto : OrdenServicioCabeceraCrearDto
+    {
+        public string Proveedor { get; set; } = string.Empty;
+        public decimal Costo { get; set; }
+    }
+}

--- a/nest.core.infraestructura.db/DbContext/LogisticaDbContext.cs
+++ b/nest.core.infraestructura.db/DbContext/LogisticaDbContext.cs
@@ -2,6 +2,7 @@
 using nest.core.dominio.Logistica;
 using nest.core.dominio.Logistica.AlmacenEN;
 using nest.core.dominio.Logistica.Transaccional;
+using nest.core.dominio.Logistica.OrdenServicio;
 
 namespace nest.core.infraestructura.db.DbContext
 {
@@ -14,5 +15,7 @@ namespace nest.core.infraestructura.db.DbContext
         public DbSet<UnidadMedida> UnidadMedida { get; set; }
         public DbSet<InventarioCabecera> InventarioCabecera { get; set; }
         public DbSet<InventarioDetalle> InventarioDetalle { get; set; }
+        public DbSet<OrdenServicioCabecera> OrdenServicioCabecera { get; set; }
+        public DbSet<OrdenServicioMantenimientoExterno> OrdenServicioMantenimientoExterno { get; set; }
     }
 }

--- a/nest.core.infraestructura.logistica/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.logistica/Mapper/AutomapperProfiles.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using nest.core.dominio.Logistica.AlmacenEN;
+using nest.core.dominio.Logistica.OrdenServicio;
 
 namespace nest.core.infraestructura.logistica.Mapper
 {
@@ -8,6 +9,8 @@ namespace nest.core.infraestructura.logistica.Mapper
         public AutomapperProfiles()
         {
             CreateMap<AlmacenCrearDto, Almacen>();
+            CreateMap<OrdenServicioCabeceraCrearDto, OrdenServicioCabecera>();
+            CreateMap<OrdenServicioMantenimientoExternoCrearDto, OrdenServicioMantenimientoExterno>();
         }
     }
 }

--- a/nest.core.infraestructura.logistica/OrdenServicioCabeceraRepository.cs
+++ b/nest.core.infraestructura.logistica/OrdenServicioCabeceraRepository.cs
@@ -1,0 +1,54 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Logistica.OrdenServicio;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.infrastructura.utils.Excepciones;
+
+namespace nest.core.infraestructura.logistica
+{
+    public class OrdenServicioCabeceraRepository : IOrdenServicioCabeceraRepository
+    {
+        private readonly NestDbContext context;
+        private readonly IMapper mapper;
+        public OrdenServicioCabeceraRepository(NestDbContext context, IMapper mapper)
+        {
+            this.context = context;
+            this.mapper = mapper;
+        }
+
+        public async Task<OrdenServicioCabecera> ObtenerPorId(int id) =>
+            await context.OrdenServicioCabecera.FirstOrDefaultAsync(x => x.Id == id);
+
+        public async Task<List<OrdenServicioCabecera>> ObtenerTodos() =>
+            await context.OrdenServicioCabecera.ToListAsync();
+
+        public async Task<OrdenServicioCabecera> Agregar(OrdenServicioCabeceraCrearDto entry)
+        {
+            var entity = mapper.Map<OrdenServicioCabecera>(entry);
+            await context.OrdenServicioCabecera.AddAsync(entity);
+            await context.SaveChangesAsync();
+            await context.Entry(entity).ReloadAsync();
+            return entity;
+        }
+
+        public async Task<OrdenServicioCabecera> Modificar(int id, OrdenServicioCabeceraCrearDto entry)
+        {
+            var existente = await context.OrdenServicioCabecera.FirstOrDefaultAsync(x => x.Id == id);
+            if (existente == null)
+                throw new RegistroNoEncontradoException<OrdenServicioCabecera>(id);
+            mapper.Map(entry, existente);
+            await context.SaveChangesAsync();
+            await context.Entry(existente).ReloadAsync();
+            return existente;
+        }
+
+        public async Task Eliminar(int id)
+        {
+            var existente = await context.OrdenServicioCabecera.FindAsync(id);
+            if (existente == null)
+                throw new RegistroNoEncontradoException<OrdenServicioCabecera>(id);
+            context.OrdenServicioCabecera.Remove(existente);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/nest.core.infraestructura.logistica/OrdenServicioMantenimientoExternoRepository.cs
+++ b/nest.core.infraestructura.logistica/OrdenServicioMantenimientoExternoRepository.cs
@@ -1,0 +1,62 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Logistica.OrdenServicio;
+using nest.core.infraestructura.db.DbContext;
+
+namespace nest.core.infraestructura.logistica
+{
+    public class OrdenServicioMantenimientoExternoRepository : IOrdenServicioMantenimientoExternoRepository
+    {
+        private readonly NestDbContext context;
+        private readonly IOrdenServicioCabeceraRepository cabeceraRepository;
+        private readonly IMapper mapper;
+        public OrdenServicioMantenimientoExternoRepository(
+            NestDbContext context,
+            IOrdenServicioCabeceraRepository cabeceraRepository,
+            IMapper mapper)
+        {
+            this.context = context;
+            this.cabeceraRepository = cabeceraRepository;
+            this.mapper = mapper;
+        }
+
+        public Task<OrdenServicioCabecera> ObtenerPorId(int id) => cabeceraRepository.ObtenerPorId(id);
+
+        public Task<List<OrdenServicioCabecera>> ObtenerTodos() => cabeceraRepository.ObtenerTodos();
+
+        public async Task<OrdenServicioMantenimientoExterno> Agregar(OrdenServicioMantenimientoExternoCrearDto entry)
+        {
+            var cabecera = await cabeceraRepository.Agregar(entry);
+            var entity = mapper.Map<OrdenServicioMantenimientoExterno>(entry);
+            entity.Id = cabecera.Id;
+            await context.OrdenServicioMantenimientoExterno.AddAsync(entity);
+            await context.SaveChangesAsync();
+            await context.Entry(entity).ReloadAsync();
+            return entity;
+        }
+
+        public async Task<OrdenServicioCabecera> Modificar(int id, OrdenServicioMantenimientoExternoCrearDto entry)
+        {
+            var cabecera = await cabeceraRepository.Modificar(id, entry);
+            var detalle = await context.OrdenServicioMantenimientoExterno.FirstOrDefaultAsync(x => x.Id == id);
+            if (detalle != null)
+            {
+                mapper.Map(entry, detalle);
+                await context.SaveChangesAsync();
+                await context.Entry(detalle).ReloadAsync();
+            }
+            return cabecera;
+        }
+
+        public async Task Eliminar(int id)
+        {
+            await cabeceraRepository.Eliminar(id);
+            var detalle = await context.OrdenServicioMantenimientoExterno.FindAsync(id);
+            if (detalle != null)
+            {
+                context.OrdenServicioMantenimientoExterno.Remove(detalle);
+                await context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/nest.core.logistica/Controllers/OrdenServicioCabeceraController.cs
+++ b/nest.core.logistica/Controllers/OrdenServicioCabeceraController.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.dominio;
+using nest.core.aplicacion.logistica;
+using nest.core.dominio.Logistica.OrdenServicio;
+
+namespace nest.core.logistica.Controllers
+{
+    /// <summary>
+    /// Controlador para gestionar ordenes de servicio genéricas.
+    /// </summary>
+    [Authorize]
+    [Route("[controller]")]
+    [ApiController]
+    public class OrdenServicioCabeceraController : ControllerBase
+    {
+        private readonly OrdenServicioCabeceraService service;
+        private readonly ILogger<OrdenServicioCabeceraController> logger;
+        public OrdenServicioCabeceraController(OrdenServicioCabeceraService service, ILogger<OrdenServicioCabeceraController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>Obtiene todas las ordenes de servicio.</summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<OrdenServicioCabecera>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<OrdenServicioCabecera>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Obtiene una orden de servicio por id.</summary>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(OrdenServicioCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioCabecera>> ObtenerPorId(int id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Agrega una nueva orden de servicio.</summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(OrdenServicioCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioCabecera>> Agregar([FromBody] OrdenServicioCabeceraCrearDto entry)
+        {
+            try
+            {
+                var data = await service.Agregar(entry);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Modifica una orden de servicio existente.</summary>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(OrdenServicioCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioCabecera>> Modificar(int id, [FromBody] OrdenServicioCabeceraCrearDto entry)
+        {
+            try
+            {
+                var data = await service.Modificar(id, entry);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Elimina una orden de servicio.</summary>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(int id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+    }
+}

--- a/nest.core.logistica/Controllers/OrdenServicioMantenimientoExternoController.cs
+++ b/nest.core.logistica/Controllers/OrdenServicioMantenimientoExternoController.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.dominio;
+using nest.core.aplicacion.logistica;
+using nest.core.dominio.Logistica.OrdenServicio;
+
+namespace nest.core.logistica.Controllers
+{
+    /// <summary>
+    /// Controlador para ordenes de servicio de mantenimiento externo.
+    /// </summary>
+    [Authorize]
+    [Route("[controller]")]
+    [ApiController]
+    public class OrdenServicioMantenimientoExternoController : ControllerBase
+    {
+        private readonly OrdenServicioMantenimientoExternoService service;
+        private readonly ILogger<OrdenServicioMantenimientoExternoController> logger;
+        public OrdenServicioMantenimientoExternoController(OrdenServicioMantenimientoExternoService service, ILogger<OrdenServicioMantenimientoExternoController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>Obtiene todas las ordenes de mantenimiento externo.</summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<OrdenServicioCabecera>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<OrdenServicioCabecera>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Obtiene una orden de mantenimiento externo por id.</summary>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(OrdenServicioCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioCabecera>> ObtenerPorId(int id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Agrega una nueva orden de mantenimiento externo.</summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(OrdenServicioMantenimientoExterno), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioMantenimientoExterno>> Agregar([FromBody] OrdenServicioMantenimientoExternoCrearDto entry)
+        {
+            try
+            {
+                var data = await service.Agregar(entry);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Modifica una orden de mantenimiento externo.</summary>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(OrdenServicioCabecera), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<OrdenServicioCabecera>> Modificar(int id, [FromBody] OrdenServicioMantenimientoExternoCrearDto entry)
+        {
+            try
+            {
+                var data = await service.Modificar(id, entry);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+
+        /// <summary>Elimina una orden de mantenimiento externo.</summary>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(int id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(new ErrorMessage { Server = true, Message = ex.Message });
+            }
+        }
+    }
+}

--- a/nest.core.logistica/Extensions/ConfigureServices.cs
+++ b/nest.core.logistica/Extensions/ConfigureServices.cs
@@ -8,6 +8,8 @@ namespace nest.core.logistica.Extensions
         {
             services.ConfigureInfraestructura(configuration);
             services.AddScoped<AlmacenService>();
+            services.AddScoped<OrdenServicioCabeceraService>();
+            services.AddScoped<OrdenServicioMantenimientoExternoService>();
             return services;
         }
     }


### PR DESCRIPTION
## Summary
- add generic service order domain, repository, service, and controller
- implement external maintenance service orders built on the generic flow
- wire up dependency injection and mappings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a966f0c8333ac98a44d708eef5e