### PR TITLE
Add Dockerfile for nest.core.security

### DIFF
--- a/nest.core.security/Dockerfile
+++ b/nest.core.security/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["nest.core.security/nest.core.security.csproj", "nest.core.security/"]
+RUN dotnet restore "nest.core.security/nest.core.security.csproj"
+COPY . .
+WORKDIR "/src/nest.core.security"
+RUN dotnet build "nest.core.security.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "nest.core.security.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "nest.core.security.dll"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for nest.core.security service

## Testing
- `dotnet build nest.core.security/nest.core.security.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c06a61576c83339388eaf494d11286