### PR TITLE
Add UsuarioEmpresa API support

### DIFF
--- a/nest.core.aplicacion.security/ConfigureServices.cs
+++ b/nest.core.aplicacion.security/ConfigureServices.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using nest.core.dominio.Security.Auth;
+using nest.core.dominio.Security.UsuarioEmpresa;
 using nest.core.infraestructura.security;
 using nest.core.infraestructura.security.Security;
 using nest.core.infraestructura.security.Aplicacion;
@@ -34,6 +35,7 @@ namespace nest.core.aplicacion.security
             services.AddTransient<IModuloRepository, ModuloRepository>();
             services.AddTransient<IFormularioRepository, FormularioRepository>();
             services.AddTransient<IEmpresaRepository, EmpresaRepository>();
+            services.AddTransient<IUsuarioEmpresaRepository, UsuarioEmpresaRepository>();
             services.AddTransient<IConnectionStringService>((services) => AuthClaim.constructClaimsAuth(services, configuration));
             return services;
         }

--- a/nest.core.aplicacion.security/UsuarioEmpresaServices/UsuarioEmpresaService.cs
+++ b/nest.core.aplicacion.security/UsuarioEmpresaServices/UsuarioEmpresaService.cs
@@ -1,4 +1,6 @@
 ﻿using nest.core.dominio.Security.UsuarioEmpresa;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace nest.core.aplicacion.security.UsuarioEmpresaServices
 {
@@ -15,6 +17,6 @@ namespace nest.core.aplicacion.security.UsuarioEmpresaServices
         public Task<UsuarioEmpresa> Agregar(UsuarioEmpresaCrearDto entry) => repository.Agregar(entry);
         public Task<UsuarioEmpresa> Modificar(long id, UsuarioEmpresaCrearDto entry) => repository.Modificar(id, entry);
         public Task Eliminar(long id) => repository.Eliminar(id);
-        public Task Seleccionar(int EmpresaId, string UsuarioId) => repository.Seleccionar(EmpresaId, UsuarioId);
+        public Task Seleccionar(UsuarioEmpresaSeleccionarDto entry) => repository.Seleccionar(entry.EmpresaId, entry.UsuarioId);
     }
 }

--- a/nest.core.dominio/Security/UsuarioEmpresa/IUsuarioEmpresaRepository.cs
+++ b/nest.core.dominio/Security/UsuarioEmpresa/IUsuarioEmpresaRepository.cs
@@ -1,4 +1,7 @@
-﻿namespace nest.core.dominio.Security.UsuarioEmpresa
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace nest.core.dominio.Security.UsuarioEmpresa
 {
     public interface IUsuarioEmpresaRepository
     {

--- a/nest.core.dominio/Security/UsuarioEmpresa/UsuarioEmpresaSeleccionarDto.cs
+++ b/nest.core.dominio/Security/UsuarioEmpresa/UsuarioEmpresaSeleccionarDto.cs
@@ -1,0 +1,8 @@
+﻿namespace nest.core.dominio.Security.UsuarioEmpresa
+{
+    public class UsuarioEmpresaSeleccionarDto
+    {
+        public string UsuarioId { get; set; }
+        public int EmpresaId { get; set; }
+    }
+}

--- a/nest.core.infraestructura.security/Security/UsuarioEmpresaRepository.cs
+++ b/nest.core.infraestructura.security/Security/UsuarioEmpresaRepository.cs
@@ -1,38 +1,62 @@
 ﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
 using nest.core.dominio.Security.UsuarioEmpresa;
 using nest.core.infraestructura.db.DbContext;
 using nest.core.infraestructura.db.Utils;
-using System.Data.Entity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace nest.core.infraestructura.security.Security
 {
     public class UsuarioEmpresaRepository : CrudRepositoryBase<UsuarioEmpresa, UsuarioEmpresaCrearDto, long>, IUsuarioEmpresaRepository
     {
-        public UsuarioEmpresaRepository(NestDbContext context, IMapper mapper) : base(context, mapper) { }
-        protected override IQueryable<UsuarioEmpresa> Query()
+        public UsuarioEmpresaRepository(NestDbContext context, IMapper mapper) : base(context, mapper)
         {
-            return context.UsuarioEmpresa.AsNoTracking()
+        }
+
+        protected override IQueryable<UsuarioEmpresa> Query() =>
+            context.UsuarioEmpresa.AsNoTracking()
                 .Include(x => x.Empresa)
                 .Include(x => x.Usuario);
-        }
+
         public async Task<UsuarioEmpresa> ObtenerPorId(long id) => await GetByIdAsync(id);
+
         public async Task<List<UsuarioEmpresa>> ObtenerTodos() => await GetAllAsync();
-        public async Task<List<UsuarioEmpresa>> GetAllByUsuarioIdAsync(string UsuarioId) => await this.context.UsuarioEmpresa.Where(x => x.UsuarioId == UsuarioId).ToListAsync();
+
+        public async Task<List<UsuarioEmpresa>> GetAllByUsuarioIdAsync(string UsuarioId) =>
+            await Query()
+                .Where(x => x.UsuarioId == UsuarioId)
+                .ToListAsync();
+
         public async Task<UsuarioEmpresa> Agregar(UsuarioEmpresaCrearDto entry) => await AddAsync(entry);
+
         public async Task<UsuarioEmpresa> Modificar(long id, UsuarioEmpresaCrearDto entry) => await UpdateAsync(id, entry);
+
         public async Task Eliminar(long id) => await DeleteAsync(id);
+
         public async Task Seleccionar(int EmpresaId, string UsuarioId)
         {
-            List<UsuarioEmpresa> lsUsuarios = await GetAllByUsuarioIdAsync(UsuarioId);
-            var registroActual = lsUsuarios.Where(x => x.EmpresaId == EmpresaId).FirstOrDefault();
-            if (registroActual == null)
-                throw new Exception("No tienes acceso a esa empresa");
-            else
+            if (string.IsNullOrWhiteSpace(UsuarioId))
             {
-                lsUsuarios.ForEach(user => user.Actual = false);
-                registroActual.Actual = true;
+                throw new ArgumentException("El identificador del usuario es requerido.", nameof(UsuarioId));
             }
-            await this.context.SaveChangesAsync();
+
+            var usuarioEmpresas = await context.UsuarioEmpresa
+                .Where(x => x.UsuarioId == UsuarioId)
+                .ToListAsync();
+
+            var registroActual = usuarioEmpresas.FirstOrDefault(x => x.EmpresaId == EmpresaId);
+            if (registroActual == null)
+            {
+                throw new Exception("No tienes acceso a esa empresa");
+            }
+
+            usuarioEmpresas.ForEach(user => user.Actual = false);
+            registroActual.Actual = true;
+
+            await context.SaveChangesAsync();
         }
     }
 }

--- a/nest.core.security/Controllers/UsuarioEmpresaController.cs
+++ b/nest.core.security/Controllers/UsuarioEmpresaController.cs
@@ -1,0 +1,189 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.security.UsuarioEmpresaServices;
+using nest.core.dominio;
+using nest.core.dominio.Security.UsuarioEmpresa;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace nest.core.security.Controllers
+{
+    /// <summary>
+    /// Controlador para administrar las relaciones entre usuarios y empresas.
+    /// Permite realizar operaciones CRUD y seleccionar la empresa activa para un usuario.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class UsuarioEmpresaController : Controller
+    {
+        private readonly UsuarioEmpresaService service;
+        private readonly ILogger<UsuarioEmpresaController> logger;
+
+        /// <summary>
+        /// Inicializa una nueva instancia del controlador <see cref="UsuarioEmpresaController"/>.
+        /// </summary>
+        /// <param name="service">Servicio que gestiona las relaciones usuario-empresa.</param>
+        /// <param name="logger">Logger para registrar eventos y errores.</param>
+        public UsuarioEmpresaController(UsuarioEmpresaService service, ILogger<UsuarioEmpresaController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todas las relaciones usuario-empresa registradas.
+        /// </summary>
+        /// <returns>Lista de relaciones usuario-empresa.</returns>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<UsuarioEmpresa>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<UsuarioEmpresa>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene una relación usuario-empresa por su identificador.
+        /// </summary>
+        /// <param name="id">Identificador de la relación usuario-empresa.</param>
+        /// <returns>Relación usuario-empresa encontrada.</returns>
+        [HttpGet("{id:long}")]
+        [ProducesResponseType(typeof(UsuarioEmpresa), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<UsuarioEmpresa>> ObtenerPorId(long id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Obtiene las relaciones usuario-empresa asociadas a un usuario específico.
+        /// </summary>
+        /// <param name="usuarioId">Identificador del usuario.</param>
+        /// <returns>Lista de relaciones usuario-empresa para el usuario.</returns>
+        [HttpGet("usuario/{usuarioId}")]
+        [ProducesResponseType(typeof(List<UsuarioEmpresa>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<UsuarioEmpresa>>> ObtenerPorUsuario(string usuarioId)
+        {
+            try
+            {
+                var data = await service.ObtenerByUsuarioIdAsync(usuarioId);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Registra una nueva relación usuario-empresa.
+        /// </summary>
+        /// <param name="registro">Información de la relación usuario-empresa.</param>
+        /// <returns>Relación creada.</returns>
+        [HttpPost]
+        [ProducesResponseType(typeof(UsuarioEmpresa), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<UsuarioEmpresa>> Agregar([FromBody] UsuarioEmpresaCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Modifica una relación usuario-empresa existente.
+        /// </summary>
+        /// <param name="id">Identificador de la relación a modificar.</param>
+        /// <param name="registro">Datos actualizados de la relación.</param>
+        /// <returns>Relación modificada.</returns>
+        [HttpPut("{id:long}")]
+        [ProducesResponseType(typeof(UsuarioEmpresa), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<UsuarioEmpresa>> Modificar(long id, [FromBody] UsuarioEmpresaCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Elimina una relación usuario-empresa.
+        /// </summary>
+        /// <param name="id">Identificador de la relación a eliminar.</param>
+        /// <returns>Resultado de la operación.</returns>
+        [HttpDelete("{id:long}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(long id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+
+        /// <summary>
+        /// Selecciona la empresa activa para un usuario.
+        /// </summary>
+        /// <param name="registro">Datos con el usuario y la empresa a seleccionar.</param>
+        /// <returns>Resultado de la operación.</returns>
+        [HttpPost("seleccionar")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> SeleccionarEmpresa([FromBody] UsuarioEmpresaSeleccionarDto registro)
+        {
+            try
+            {
+                await service.Seleccionar(registro);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return BadRequest(GenerateMessage.Create(ex));
+            }
+        }
+    }
+}

--- a/nest.core.security/Extensions/ConfigureServices.cs
+++ b/nest.core.security/Extensions/ConfigureServices.cs
@@ -3,6 +3,7 @@ using nest.core.aplicacion.security.Aplicacion;
 using nest.core.aplicacion.security.Corporativo;
 using nest.core.aplicacion.security.Login;
 using nest.core.aplicacion.security.Security;
+using nest.core.aplicacion.security.UsuarioEmpresaServices;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
 
@@ -22,6 +23,7 @@ namespace nest.core.security.Extensions
             services.AddScoped<RoleClaimsService>();
             services.AddScoped<UsuarioService>();
             services.AddScoped<RoleUsuarioService>();
+            services.AddScoped<UsuarioEmpresaService>();
             return services;
         }
 


### PR DESCRIPTION
## Summary
- register the UsuarioEmpresa repository and service in the security application DI setup
- add DTO, service update, repository improvements, and REST controller for managing user-company assignments
- expose endpoints to retrieve, modify, delete, and select active companies for users

## Testing
- dotnet build nest.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8713664248333a71b9e31438a7d9a