### PR TITLE
Add RegistroAsistencia services and API endpoints

### DIFF
--- a/nest.core.aplicacion.rrhh/ConfigureServices.cs
+++ b/nest.core.aplicacion.rrhh/ConfigureServices.cs
@@ -6,6 +6,7 @@ using nest.core.dominio.RRHH.GrupoHorarioEntities;
 using nest.core.dominio.RRHH.HorarioCabeceraEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
 using nest.core.dominio.RRHH.PersonalEstadoEntities;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
 using nest.core.dominio.Security.Tenant;
 using nest.core.infraestructura.rrhh;
 
@@ -22,6 +23,7 @@ namespace nest.core.aplicacion.rrhh
             services.AddTransient<IHorarioRepository, HorarioRepository>();
             services.AddTransient<IPersonalRepository, PersonalRepository>();
             services.AddTransient<IPersonalEstadoRepository, PersonalEstadoRepository>();
+            services.AddTransient<IRegistroAsistenciaRepository, RegistroAsistenciaRepository>();
             return services;
         }
     }

--- a/nest.core.aplicacion.rrhh/RegistroAsistenciaServices/RegistroAsistenciaService.cs
+++ b/nest.core.aplicacion.rrhh/RegistroAsistenciaServices/RegistroAsistenciaService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
+
+namespace nest.core.aplicacion.rrhh.RegistroAsistenciaServices
+{
+    public class RegistroAsistenciaService
+    {
+        private readonly IRegistroAsistenciaRepository repository;
+
+        public RegistroAsistenciaService(IRegistroAsistenciaRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<RegistroAsistencia> ObtenerPorId(long id) => repository.ObtenerPorId(id);
+        public Task<List<RegistroAsistencia>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<List<RegistroAsistencia>> BuscarPorRangoFecha(int personalId, DateTime fechaInicio, DateTime fechaFin) => repository.BuscarPorRangoFecha(personalId, fechaInicio, fechaFin);
+        public Task<RegistroAsistencia> Agregar(RegistroAsistenciaCrearDto entry) => repository.Agregar(entry);
+        public Task<RegistroAsistencia> Modificar(long id, RegistroAsistenciaCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(long id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.dominio/RRHH/RegistroAsistenciaEntities/IRegistroAsistenciaRepository.cs
+++ b/nest.core.dominio/RRHH/RegistroAsistenciaEntities/IRegistroAsistenciaRepository.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace nest.core.dominio.RRHH.RegistroAsistenciaEntities
+{
+    public interface IRegistroAsistenciaRepository
+    {
+        Task<RegistroAsistencia> ObtenerPorId(long id);
+        Task<List<RegistroAsistencia>> ObtenerTodos();
+        Task<List<RegistroAsistencia>> BuscarPorRangoFecha(int personalId, DateTime fechaInicio, DateTime fechaFin);
+        Task<RegistroAsistencia> Agregar(RegistroAsistenciaCrearDto entidad);
+        Task<RegistroAsistencia> Modificar(long id, RegistroAsistenciaCrearDto entidad);
+        Task Eliminar(long id);
+    }
+}

--- a/nest.core.dominio/RRHH/RegistroAsistenciaEntities/RegistroAsistenciaCrearDto.cs
+++ b/nest.core.dominio/RRHH/RegistroAsistenciaEntities/RegistroAsistenciaCrearDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace nest.core.dominio.RRHH.RegistroAsistenciaEntities
+{
+    public class RegistroAsistenciaCrearDto
+    {
+        public int EmpresaId { get; set; }
+        public long Id { get; set; }
+        public int PersonalId { get; set; }
+        public int GrupoHorarioId { get; set; }
+        public DateTime Fecha { get; set; }
+        public int DiferenciaMinutos { get; set; }
+        public long HorarioDetalleId { get; set; }
+    }
+}

--- a/nest.core.infraestructura.rrhh/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.rrhh/Mapper/AutomapperProfiles.cs
@@ -5,6 +5,7 @@ using nest.core.dominio.RRHH.HorarioCabeceraEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
 using nest.core.dominio.RRHH.PersonalEstadoEntities;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
 
 namespace nest.core.infraestructura.rrhh.Mapper
 {
@@ -18,6 +19,7 @@ namespace nest.core.infraestructura.rrhh.Mapper
             CreateMap<HorarioDetalleCrearDto, HorarioDetalle>();
             CreateMap<PersonalCrearDto, Personal>();
             CreateMap<PersonalEstadoCrearDto, PersonalEstado>();
+            CreateMap<RegistroAsistenciaCrearDto, RegistroAsistencia>();
         }
     }
 }

--- a/nest.core.infraestructura.rrhh/RegistroAsistenciaRepository.cs
+++ b/nest.core.infraestructura.rrhh/RegistroAsistenciaRepository.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.infraestructura.db.Utils;
+using nest.core.infrastructura.utils.Excepciones;
+
+namespace nest.core.infraestructura.rrhh
+{
+    public class RegistroAsistenciaRepository : CrudRepositoryBase<RegistroAsistencia, RegistroAsistenciaCrearDto, long>, IRegistroAsistenciaRepository
+    {
+        public RegistroAsistenciaRepository(NestDbContext context, IMapper mapper) : base(context, mapper)
+        {
+        }
+
+        protected override IQueryable<RegistroAsistencia> Query() => context.Set<RegistroAsistencia>()
+            .AsNoTracking()
+            .Include(x => x.Personal)
+            .Include(x => x.GrupoHorario)
+            .Include(x => x.HorarioDetalle);
+
+        public async Task<RegistroAsistencia> ObtenerPorId(long id) =>
+            await GetByIdAsync(id) ?? throw new RegistroNoEncontradoException<RegistroAsistencia>(id.ToString());
+        public Task<List<RegistroAsistencia>> ObtenerTodos() => GetAllAsync();
+
+        public async Task<List<RegistroAsistencia>> BuscarPorRangoFecha(int personalId, DateTime fechaInicio, DateTime fechaFin)
+        {
+            if (fechaFin < fechaInicio)
+            {
+                (fechaInicio, fechaFin) = (fechaFin, fechaInicio);
+            }
+
+            return await Query()
+                .Where(x => x.PersonalId == personalId && x.Fecha >= fechaInicio && x.Fecha <= fechaFin)
+                .OrderBy(x => x.Fecha)
+                .ToListAsync();
+        }
+
+        public async Task<RegistroAsistencia> Agregar(RegistroAsistenciaCrearDto entry)
+        {
+            await AddAsync(entry);
+            return await ObtenerPorId(entry.Id);
+        }
+
+        public async Task<RegistroAsistencia> Modificar(long id, RegistroAsistenciaCrearDto entry)
+        {
+            await UpdateAsync(id, entry);
+            return await ObtenerPorId(id);
+        }
+
+        public Task Eliminar(long id) => DeleteAsync(id);
+    }
+}

--- a/nest.core.rrhh/Controllers/RegistroAsistenciaController.cs
+++ b/nest.core.rrhh/Controllers/RegistroAsistenciaController.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.rrhh.RegistroAsistenciaServices;
+using nest.core.dominio;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
+
+namespace nest.core.rrhh.Controllers
+{
+    /// <summary>
+    /// Controlador para la gestión de registros de asistencia.
+    /// Permite consultar, crear, actualizar y eliminar marcaciones de asistencia del personal.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class RegistroAsistenciaController : ControllerBase
+    {
+        private readonly RegistroAsistenciaService service;
+        private readonly ILogger<RegistroAsistenciaController> logger;
+
+        /// <summary>
+        /// Inicializa una nueva instancia del controlador <see cref="RegistroAsistenciaController"/>.
+        /// </summary>
+        /// <param name="service">Servicio de aplicación que gestiona la lógica de registros de asistencia.</param>
+        /// <param name="logger">Instancia de <see cref="ILogger"/> para el registro de eventos.</param>
+        public RegistroAsistenciaController(RegistroAsistenciaService service, ILogger<RegistroAsistenciaController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Obtiene todos los registros de asistencia disponibles.
+        /// </summary>
+        /// <returns>Lista de registros de asistencia.</returns>
+        /// <response code="200">Devuelve la colección de registros de asistencia.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(List<RegistroAsistencia>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<RegistroAsistencia>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Obtiene un registro de asistencia específico por su identificador.
+        /// </summary>
+        /// <param name="id">Identificador del registro de asistencia.</param>
+        /// <returns>Registro de asistencia correspondiente.</returns>
+        /// <response code="200">Registro encontrado.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(RegistroAsistencia), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<RegistroAsistencia>> ObtenerPorId(long id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Busca registros de asistencia de un personal en un rango de fechas.
+        /// </summary>
+        /// <param name="personalId">Identificador del personal.</param>
+        /// <param name="fechaInicio">Fecha inicial del filtro (inclusive).</param>
+        /// <param name="fechaFin">Fecha final del filtro (inclusive).</param>
+        /// <returns>Lista de registros de asistencia que coinciden con el filtro.</returns>
+        /// <response code="200">Devuelve la lista filtrada de registros.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpGet("personal/{personalId}")]
+        [ProducesResponseType(typeof(List<RegistroAsistencia>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<RegistroAsistencia>>> BuscarPorRangoFecha(int personalId, [FromQuery] DateTime fechaInicio, [FromQuery] DateTime fechaFin)
+        {
+            try
+            {
+                var data = await service.BuscarPorRangoFecha(personalId, fechaInicio, fechaFin);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Crea un nuevo registro de asistencia.
+        /// </summary>
+        /// <param name="registro">Datos del registro de asistencia a crear.</param>
+        /// <returns>Registro de asistencia creado.</returns>
+        /// <response code="200">Registro creado correctamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPost]
+        [ProducesResponseType(typeof(RegistroAsistencia), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<RegistroAsistencia>> Agregar([FromBody] RegistroAsistenciaCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Actualiza un registro de asistencia existente.
+        /// </summary>
+        /// <param name="id">Identificador del registro que se desea actualizar.</param>
+        /// <param name="registro">Datos actualizados del registro de asistencia.</param>
+        /// <returns>Registro de asistencia actualizado.</returns>
+        /// <response code="200">Registro actualizado correctamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(RegistroAsistencia), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<RegistroAsistencia>> Modificar(long id, [FromBody] RegistroAsistenciaCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Elimina un registro de asistencia.
+        /// </summary>
+        /// <param name="id">Identificador del registro a eliminar.</param>
+        /// <returns>Resultado de la operación.</returns>
+        /// <response code="200">Registro eliminado correctamente.</response>
+        /// <response code="400">Error en la solicitud.</response>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(long id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/nest.core.rrhh/Extensions/ConfigureServices.cs
+++ b/nest.core.rrhh/Extensions/ConfigureServices.cs
@@ -4,6 +4,7 @@ using nest.core.aplicacion.rrhh.GrupoHorarioServices;
 using nest.core.aplicacion.rrhh.HorarioServices;
 using nest.core.aplicacion.rrhh.PersonalEstadoServices;
 using nest.core.aplicacion.rrhh.PersonalServices;
+using nest.core.aplicacion.rrhh.RegistroAsistenciaServices;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
 
@@ -20,6 +21,7 @@ namespace nest.core.rrhh.Extensions
             services.AddScoped<HorarioService>();
             services.AddScoped<PersonalEstadoService>();
             services.AddScoped<PersonalService>();
+            services.AddScoped<RegistroAsistenciaService>();
             return services;
         }
 


### PR DESCRIPTION
## Summary
- add RegistroAsistencia DTOs and repository interface in the RRHH domain layer
- implement infrastructure repository, AutoMapper mappings, and application service for RegistroAsistencia
- register the new components and expose RegistroAsistencia CRUD/search endpoints with Swagger documentation

## Testing
- dotnet build nest.core.rrhh/nest.core.rrhh.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d821be3e588333897a9e0f6154915f