### PR TITLE
Add patrimonial Activo API and supporting layers

### DIFF
--- a/nest.core.aplicacion.patrimonial/ActivoServices/ActivoService.cs
+++ b/nest.core.aplicacion.patrimonial/ActivoServices/ActivoService.cs
@@ -1,0 +1,20 @@
+using nest.core.dominio.Patrimonial.ActivoEntities;
+
+namespace nest.core.aplicacion.patrimonial.ActivoServices
+{
+    public class ActivoService
+    {
+        private readonly IActivoRepository repository;
+        public ActivoService(IActivoRepository repository)
+        {
+            this.repository = repository;
+        }
+
+        public Task<Activo> ObtenerPorId(long id) => repository.ObtenerPorId(id);
+        public Task<List<Activo>> ObtenerTodos() => repository.ObtenerTodos();
+        public Task<List<Activo>> ObtenerActivos() => repository.ObtenerActivos();
+        public Task<Activo> Agregar(ActivoCrearDto entry) => repository.Agregar(entry);
+        public Task<Activo> Modificar(long id, ActivoCrearDto entry) => repository.Modificar(id, entry);
+        public Task Eliminar(long id) => repository.Eliminar(id);
+    }
+}

--- a/nest.core.aplicacion.patrimonial/ConfigureServices.cs
+++ b/nest.core.aplicacion.patrimonial/ConfigureServices.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using nest.core.aplication.auth;
+using nest.core.dominio.Patrimonial.ActivoEntities;
+using nest.core.dominio.Security.Tenant;
+using nest.core.infraestructura.patrimonial;
+
+namespace nest.core.aplicacion.patrimonial
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureInfraestructura(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.AddAutoMapper(typeof(infraestructura.patrimonial.Mapper.AutomapperProfiles));
+            services.AddTransient<IConnectionStringService>(provider => AuthClaim.constructClaimsAuth(provider, configuration));
+            services.AddTransient<IActivoRepository, ActivoRepository>();
+            return services;
+        }
+    }
+}

--- a/nest.core.aplicacion.patrimonial/nest.core.aplicacion.patrimonial.csproj
+++ b/nest.core.aplicacion.patrimonial/nest.core.aplicacion.patrimonial.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplication.auth\nest.core.aplication.auth.csproj" />
+    <ProjectReference Include="..\nest.core.dominio\nest.core.dominio.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.patrimonial\nest.core.infraestructura.patrimonial.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.security\nest.core.infraestructura.security.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.dominio/Patrimonial/ActivoEntities/ActivoCrearDto.cs
+++ b/nest.core.dominio/Patrimonial/ActivoEntities/ActivoCrearDto.cs
@@ -1,0 +1,14 @@
+namespace nest.core.dominio.Patrimonial.ActivoEntities
+{
+    public class ActivoCrearDto
+    {
+        public int EmpresaId { get; set; }
+        public long? ProductoLoteId { get; set; }
+        public string Nombre { get; set; }
+        public string Descripcion { get; set; }
+        public int? DepreciacionMeses { get; set; }
+        public int? CentroDeCostosId { get; set; }
+        public string ImagenUrl { get; set; }
+        public int? TerceroId { get; set; }
+    }
+}

--- a/nest.core.dominio/Patrimonial/ActivoEntities/IActivoRepository.cs
+++ b/nest.core.dominio/Patrimonial/ActivoEntities/IActivoRepository.cs
@@ -1,0 +1,12 @@
+namespace nest.core.dominio.Patrimonial.ActivoEntities
+{
+    public interface IActivoRepository
+    {
+        Task<Activo> ObtenerPorId(long id);
+        Task<List<Activo>> ObtenerTodos();
+        Task<List<Activo>> ObtenerActivos();
+        Task<Activo> Agregar(ActivoCrearDto entry);
+        Task<Activo> Modificar(long id, ActivoCrearDto entry);
+        Task Eliminar(long id);
+    }
+}

--- a/nest.core.infraestructura.patrimonial/ActivoRepository.cs
+++ b/nest.core.infraestructura.patrimonial/ActivoRepository.cs
@@ -1,0 +1,23 @@
+using AutoMapper;
+using nest.core.dominio.Cache;
+using nest.core.dominio.Patrimonial.ActivoEntities;
+using nest.core.infraestructura.db.Cache;
+using nest.core.infraestructura.db.DbContext;
+
+namespace nest.core.infraestructura.patrimonial
+{
+    public class ActivoRepository : CachedRepositoryBase<Activo, ActivoCrearDto, long>, IActivoRepository
+    {
+        public ActivoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache)
+            : base(context, mapper, cache)
+        {
+        }
+
+        public Task<Activo> Agregar(ActivoCrearDto dto) => AddAsync(dto);
+        public Task Eliminar(long id) => DeleteAsync(id);
+        public Task<Activo> Modificar(long id, ActivoCrearDto dto) => UpdateAsync(id, dto);
+        public async Task<Activo> ObtenerPorId(long id) => await GetByIdAsync(id);
+        public async Task<List<Activo>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<Activo>> ObtenerActivos() => await GetAllAsync();
+    }
+}

--- a/nest.core.infraestructura.patrimonial/Mapper/AutomapperProfiles.cs
+++ b/nest.core.infraestructura.patrimonial/Mapper/AutomapperProfiles.cs
@@ -1,0 +1,13 @@
+using AutoMapper;
+using nest.core.dominio.Patrimonial.ActivoEntities;
+
+namespace nest.core.infraestructura.patrimonial.Mapper
+{
+    public class AutomapperProfiles : Profile
+    {
+        public AutomapperProfiles()
+        {
+            CreateMap<ActivoCrearDto, Activo>();
+        }
+    }
+}

--- a/nest.core.infraestructura.patrimonial/nest.core.infraestructura.patrimonial.csproj
+++ b/nest.core.infraestructura.patrimonial/nest.core.infraestructura.patrimonial.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.dominio\nest.core.dominio.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+    <ProjectReference Include="..\nest.core.infrastructura.utils\nest.core.infrastructura.utils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.patrimonial/Controllers/ActivoController.cs
+++ b/nest.core.patrimonial/Controllers/ActivoController.cs
@@ -1,0 +1,107 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.patrimonial.ActivoServices;
+using nest.core.dominio;
+using nest.core.dominio.Patrimonial.ActivoEntities;
+
+namespace nest.core.patrimonial.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class ActivoController : ControllerBase
+    {
+        private readonly ActivoService service;
+        private readonly ILogger<ActivoController> logger;
+        public ActivoController(ActivoService service, ILogger<ActivoController> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(List<Activo>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<Activo>>> ObtenerTodos()
+        {
+            try
+            {
+                var data = await service.ObtenerTodos();
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        [HttpGet("{id:long}")]
+        [ProducesResponseType(typeof(Activo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<Activo>> ObtenerPorId(long id)
+        {
+            try
+            {
+                var data = await service.ObtenerPorId(id);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        [HttpPost]
+        [ProducesResponseType(typeof(Activo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<Activo>> Agregar([FromBody] ActivoCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Agregar(registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        [HttpPut("{id:long}")]
+        [ProducesResponseType(typeof(Activo), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<Activo>> Modificar(long id, [FromBody] ActivoCrearDto registro)
+        {
+            try
+            {
+                var data = await service.Modificar(id, registro);
+                return Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+
+        [HttpDelete("{id:long}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(long id)
+        {
+            try
+            {
+                await service.Eliminar(id);
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/nest.core.patrimonial/Dockerfile
+++ b/nest.core.patrimonial/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["nest.core.patrimonial/nest.core.patrimonial.csproj", "nest.core.patrimonial/"]
+RUN dotnet restore "nest.core.patrimonial/nest.core.patrimonial.csproj"
+COPY . .
+WORKDIR "/src/nest.core.patrimonial"
+RUN dotnet build "nest.core.patrimonial.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "nest.core.patrimonial.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "nest.core.patrimonial.dll"]

--- a/nest.core.patrimonial/Extensions/ConfigureServices.cs
+++ b/nest.core.patrimonial/Extensions/ConfigureServices.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using nest.core.aplicacion.patrimonial;
+using nest.core.aplicacion.patrimonial.ActivoServices;
+using nest.core.dominio.Cache;
+using nest.core.infraestructura.db.Cache;
+
+namespace nest.core.patrimonial.Extensions
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureAplication(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            ConfigureCache(services, configuration);
+            services.ConfigureInfraestructura(configuration);
+            services.AddScoped<ActivoService>();
+            return services;
+        }
+
+        private static void ConfigureCache(IServiceCollection services, IConfigurationManager configuration)
+        {
+            bool useRedis = configuration.GetValue<bool>($"RedisConfig:Enabled");
+            if (useRedis)
+            {
+                services.AddStackExchangeRedisCache(options =>
+                {
+                    options.Configuration = configuration.GetValue<string>($"RedisConfig:ConnectionString");
+                    options.InstanceName = configuration.GetValue<string>($"RedisConfig:InstanceName");
+                });
+                services.AddScoped<ICacheRepository, RedisCacheRepository>();
+            }
+            else
+            {
+                services.AddMemoryCache();
+                services.AddScoped<ICacheRepository, MemoryCacheRepository>();
+            }
+        }
+    }
+}

--- a/nest.core.patrimonial/Program.cs
+++ b/nest.core.patrimonial/Program.cs
@@ -1,0 +1,109 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using nest.core.aplication.auth;
+using nest.core.patrimonial.Extensions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateBuilder(args);
+Console.WriteLine("Iniciando aplicación Patrimonial...");
+if (Environment.GetEnvironmentVariable("IS_LAMBDA") != null)
+    builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+
+// Add services custom
+builder.Configuration.AddJsonFile("appsettings.json", optional: true)
+                     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                     .AddUserSecrets<Program>()
+                     .AddEnvironmentVariables();
+DbContextSelector.SelectProvider(builder, true);
+builder.Services.ConfigureAplication(builder.Configuration);
+builder.Services.AddHealthChecks().AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", builder =>
+    {
+        builder.AllowAnyOrigin()
+               .AllowAnyMethod()
+               .AllowAnyHeader();
+    });
+});
+// End services custom
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+    });
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c => {
+    string proyecto = Assembly.GetExecutingAssembly().GetName().Name.Split('.')[2];
+    proyecto = char.ToUpper(proyecto[0]) + proyecto.Substring(1).ToLower();
+    string apiName = $"{proyecto} Api";
+    c.SwaggerDoc("v1", new OpenApiInfo {
+        Title = apiName,
+        Version = $"v{Assembly.GetExecutingAssembly().GetName().Version}",
+        Description = $"La {apiName} permite gestionar los activos patrimoniales, incluyendo su creación, modificación y baja. Todos los endpoints requieren autorización.",
+        Contact = new OpenApiContact { Email = "gabogth@gmail.com", Name = "Gabriel Rodriguez", Url = new Uri("https://es.stackoverflow.com/users/30423") }
+    });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "Ingrese el token JWT en este formato: Bearer {token}",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement(){
+        {
+            new OpenApiSecurityScheme {
+                Reference = new OpenApiReference {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+    c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"));
+});
+builder.Services.AddAuthentication(option =>
+{
+    option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    option.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(option =>
+{
+    option.SaveToken = true;
+    option.TokenValidationParameters = new TokenValidationParameters
+    {
+        SaveSigninToken = true,
+        ValidateIssuer = true,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Issuer"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
+
+var app = builder.Build();
+if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("BASE_URL")))
+    app.UsePathBase(Environment.GetEnvironmentVariable("BASE_URL"));
+app.UseSwagger();
+app.UseSwaggerUI();
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseCors("CorsPolicy");
+app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = check => check.Tags.Contains("live") });
+app.UseMiddleware<ErrorHandlingMiddleware>();
+app.MapControllers();
+app.Run();

--- a/nest.core.patrimonial/Properties/launchSettings.json
+++ b/nest.core.patrimonial/Properties/launchSettings.json
@@ -1,0 +1,25 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:8290"
+    },
+    "https": {
+      "commandName": "Project",
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ENGINE": "SqlServer"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:8390"
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json"
+}

--- a/nest.core.patrimonial/appsettings.Development.json
+++ b/nest.core.patrimonial/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/nest.core.patrimonial/appsettings.json
+++ b/nest.core.patrimonial/appsettings.json
@@ -1,0 +1,24 @@
+{
+  "Connections": {
+    "SqlServer": "Server=localhost,1433;Database=nest;User Id=sa;Password=4N&XY&d_0y6+;TrustServerCertificate=true;MultipleActiveResultSets=true;Application Name=Nest;",
+    "Npgsql": "Host=localhost;Port=5431;Database=nest;Username=postgres;Password=4N&XY&d_0y6+;Application Name=Nest;",
+    "MySql": "server=localhost;port=3305;database=nest;uid=root;pwd=4N&XY&d_0y6+;Application Name=Nest;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Jwt": {
+    "Issuer": "https://empresa.com",
+    "Audience": "https://empresa.com",
+    "Key": "ckO9z0o8ZppcIbrOsT8Nj58uKgZkJwOoNwNVLpJVPz0="
+  },
+  "RedisConfig": {
+    "Enabled": false,
+    "ConnectionString": "localhost:6379",
+    "InstanceName": "Nest_"
+  },
+  "AllowedHosts": "*"
+}

--- a/nest.core.patrimonial/lambda.Dockerfile
+++ b/nest.core.patrimonial/lambda.Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+ARG BUILD_CONFIGURATION=Release
+
+WORKDIR /src
+COPY ["nest.core.patrimonial/nest.core.patrimonial.csproj", "nest.core.patrimonial/"]
+RUN dotnet restore "nest.core.patrimonial/nest.core.patrimonial.csproj"
+COPY . .
+WORKDIR /src/nest.core.patrimonial
+RUN dotnet publish "nest.core.patrimonial.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:PublishReadyToRun=true
+
+FROM public.ecr.aws/lambda/dotnet:9 AS final
+WORKDIR /var/task
+COPY --from=build /app/publish ./
+
+CMD ["nest.core.patrimonial"]

--- a/nest.core.patrimonial/nest.core.patrimonial.csproj
+++ b/nest.core.patrimonial/nest.core.patrimonial.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>e5b0cf3c-c6ba-4c20-9a0e-5d8af6c1e2d6</UserSecretsId>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <FileVersion></FileVersion>
+    <AssemblyVersion>1.0.0.1</AssemblyVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.9.0" />
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplicacion.patrimonial\nest.core.aplicacion.patrimonial.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.sln
+++ b/nest.sln
@@ -79,6 +79,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.genera
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.infraestructura.general", "nest.core.infraestructura.general\nest.core.infraestructura.general.csproj", "{65163C72-679F-4432-A80D-D6B26A8E2735}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.infraestructura.patrimonial", "nest.core.infraestructura.patrimonial\nest.core.infraestructura.patrimonial.csproj", "{BEF7E734-D586-4826-8928-C4D2042325C5}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.general", "nest.core.general\nest.core.general.csproj", "{9CF72613-82B7-4E29-8EB8-0C96C17E5453}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.infraestructura.finanzas", "nest.core.infraestructura.finanzas\nest.core.infraestructura.finanzas.csproj", "{671EFF2E-E5BB-4D7F-BC8C-976064590869}"
@@ -100,6 +102,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nest.core.aplicacion.mantto", "nest.core.aplicacion.mantto\nest.core.aplicacion.mantto.csproj", "{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nest.core.infraestructura.mantto", "nest.core.infraestructura.mantto\nest.core.infraestructura.mantto.csproj", "{873AD771-2522-4EF4-9927-1A917681ECD9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.patrimonial", "nest.core.aplicacion.patrimonial\nest.core.aplicacion.patrimonial.csproj", "{8AE68B5D-804D-4B49-A599-824CB7F27BF7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.patrimonial", "nest.core.patrimonial\nest.core.patrimonial.csproj", "{A42EFDBC-68EF-465D-A3C4-5A57587F9669}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "iac", "iac", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
@@ -190,10 +196,16 @@ Global
 		{2D797AE8-F294-4E40-B7F4-BBCF99B1E4F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{873AD771-2522-4EF4-9927-1A917681ECD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{873AD771-2522-4EF4-9927-1A917681ECD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8666BE1C-00D5-49D1-8C2E-DA69E39B1B62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8666BE1C-00D5-49D1-8C2E-DA69E39B1B62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {873AD771-2522-4EF4-9927-1A917681ECD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {873AD771-2522-4EF4-9927-1A917681ECD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {BEF7E734-D586-4826-8928-C4D2042325C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {BEF7E734-D586-4826-8928-C4D2042325C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8AE68B5D-804D-4B49-A599-824CB7F27BF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8AE68B5D-804D-4B49-A599-824CB7F27BF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A42EFDBC-68EF-465D-A3C4-5A57587F9669}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A42EFDBC-68EF-465D-A3C4-5A57587F9669}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8666BE1C-00D5-49D1-8C2E-DA69E39B1B62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8666BE1C-00D5-49D1-8C2E-DA69E39B1B62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CAB3FE76-6E33-4FDE-B338-2BF03BA8F839}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CAB3FE76-6E33-4FDE-B338-2BF03BA8F839}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57ABD640-0269-4F2A-9DAB-449DF485FB27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -242,8 +254,11 @@ Global
 		{BAC84888-4510-4C02-AAF1-EA40D4160D84} = {B8494947-0BD9-4763-BC5A-40667E95E294}
 		{2D797AE8-F294-4E40-B7F4-BBCF99B1E4F9} = {B8494947-0BD9-4763-BC5A-40667E95E294}
 		{71DB6BF3-AFCE-4F0A-8BF9-9640F824A5D0} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
-		{873AD771-2522-4EF4-9927-1A917681ECD9} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
-		{8666BE1C-00D5-49D1-8C2E-DA69E39B1B62} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+                {873AD771-2522-4EF4-9927-1A917681ECD9} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
+                {BEF7E734-D586-4826-8928-C4D2042325C5} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
+                {8AE68B5D-804D-4B49-A599-824CB7F27BF7} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
+                {A42EFDBC-68EF-465D-A3C4-5A57587F9669} = {ADCC3ECF-AF23-4BD7-AA42-A2517216AF12}
+                {8666BE1C-00D5-49D1-8C2E-DA69E39B1B62} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{CAB3FE76-6E33-4FDE-B338-2BF03BA8F839} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{57ABD640-0269-4F2A-9DAB-449DF485FB27} = {7FC3797F-B49D-4CA0-858B-239AE3C16389}
 		{180FFE87-C3EE-4ECC-8E12-2F6C1A298055} = {7FC3797F-B49D-4CA0-858B-239AE3C16389}


### PR DESCRIPTION
## Summary
- add DTOs and repository contract for patrimonial Activo entities
- implement patrimonial infrastructure, application, and API projects for Activo management with Swagger docs
- register new projects in the solution and wire dependency injection plus caching configuration

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dc312a8a6c8333bc711f7b30c82c32