### PR TITLE
Add Swagger documentation to Activo API endpoints

### DIFF
--- a/nest.core.patrimonial/Controllers/ActivoController.cs
+++ b/nest.core.patrimonial/Controllers/ActivoController.cs
@@ -6,6 +6,11 @@ using nest.core.dominio.Patrimonial.ActivoEntities;
 
 namespace nest.core.patrimonial.Controllers
 {
+    /// <summary>
+    /// Controlador para la gestión de activos patrimoniales.
+    /// Permite consultar, registrar, actualizar y eliminar activos.
+    /// Todos los endpoints requieren autorización mediante token JWT.
+    /// </summary>
     [Authorize]
     [ApiController]
     [Route("[controller]")]
@@ -13,15 +18,29 @@ namespace nest.core.patrimonial.Controllers
     {
         private readonly ActivoService service;
         private readonly ILogger<ActivoController> logger;
+
+        /// <summary>
+        /// Inicializa una nueva instancia de <see cref="ActivoController"/>.
+        /// </summary>
+        /// <param name="service">Servicio de aplicación para la gestión de activos.</param>
+        /// <param name="logger">Registrador para auditoría y trazabilidad de errores.</param>
         public ActivoController(ActivoService service, ILogger<ActivoController> logger)
         {
             this.service = service;
             this.logger = logger;
         }
 
+        /// <summary>
+        /// Obtiene todos los activos registrados.
+        /// </summary>
+        /// <returns>Lista con los activos disponibles.</returns>
+        /// <response code="200">Listado obtenido correctamente.</response>
+        /// <response code="400">La solicitud es inválida.</response>
+        /// <response code="401">No autorizado.</response>
         [HttpGet]
         [ProducesResponseType(typeof(List<Activo>), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
         public async Task<ActionResult<List<Activo>>> ObtenerTodos()
         {
             try
@@ -36,9 +55,18 @@ namespace nest.core.patrimonial.Controllers
             }
         }
 
+        /// <summary>
+        /// Obtiene un activo según su identificador.
+        /// </summary>
+        /// <param name="id">Identificador único del activo.</param>
+        /// <returns>El activo correspondiente al identificador proporcionado.</returns>
+        /// <response code="200">Activo encontrado.</response>
+        /// <response code="400">La solicitud es inválida.</response>
+        /// <response code="401">No autorizado.</response>
         [HttpGet("{id:long}")]
         [ProducesResponseType(typeof(Activo), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
         public async Task<ActionResult<Activo>> ObtenerPorId(long id)
         {
             try
@@ -53,9 +81,18 @@ namespace nest.core.patrimonial.Controllers
             }
         }
 
+        /// <summary>
+        /// Crea un nuevo activo patrimonial.
+        /// </summary>
+        /// <param name="registro">Información del activo a registrar.</param>
+        /// <returns>El activo registrado.</returns>
+        /// <response code="200">Activo registrado correctamente.</response>
+        /// <response code="400">La solicitud es inválida.</response>
+        /// <response code="401">No autorizado.</response>
         [HttpPost]
         [ProducesResponseType(typeof(Activo), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
         public async Task<ActionResult<Activo>> Agregar([FromBody] ActivoCrearDto registro)
         {
             try
@@ -70,9 +107,19 @@ namespace nest.core.patrimonial.Controllers
             }
         }
 
+        /// <summary>
+        /// Actualiza la información de un activo existente.
+        /// </summary>
+        /// <param name="id">Identificador del activo a modificar.</param>
+        /// <param name="registro">Datos actualizados del activo.</param>
+        /// <returns>El activo actualizado.</returns>
+        /// <response code="200">Activo modificado exitosamente.</response>
+        /// <response code="400">La solicitud es inválida.</response>
+        /// <response code="401">No autorizado.</response>
         [HttpPut("{id:long}")]
         [ProducesResponseType(typeof(Activo), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
         public async Task<ActionResult<Activo>> Modificar(long id, [FromBody] ActivoCrearDto registro)
         {
             try
@@ -87,9 +134,18 @@ namespace nest.core.patrimonial.Controllers
             }
         }
 
+        /// <summary>
+        /// Elimina un activo patrimonial.
+        /// </summary>
+        /// <param name="id">Identificador del activo a eliminar.</param>
+        /// <returns>Resultado de la operación.</returns>
+        /// <response code="200">Activo eliminado correctamente.</response>
+        /// <response code="400">La solicitud es inválida.</response>
+        /// <response code="401">No autorizado.</response>
         [HttpDelete("{id:long}")]
-        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(bool), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
         public async Task<ActionResult> Eliminar(long id)
         {
             try


### PR DESCRIPTION
## Summary
- add XML documentation to the ActivoController to describe available endpoints in Swagger
- document response codes, including unauthorized responses and the boolean delete result

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd697b09fc833388167368978ac014