### PR TITLE
feat: agregar frontend Angular 21 para nest.core.view.security con página INDEX y login

### DIFF
--- a/nest.core.view.security/.editorconfig
+++ b/nest.core.view.security/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/nest.core.view.security/.gitignore
+++ b/nest.core.view.security/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/dist
+/.angular
+.coverage

--- a/nest.core.view.security/README.md
+++ b/nest.core.view.security/README.md
@@ -1,0 +1,17 @@
+# nest.core.view.security
+
+Proyecto Angular 21 con Bootstrap 5.3 para el módulo de seguridad.
+
+## Requisitos
+
+- Node.js 22+
+- npm 11+
+
+## Comandos
+
+```bash
+npm install
+npm start
+```
+
+La aplicación expone una página principal con el texto `INDEX` y un formulario de login conectado al servicio `nest.core.security` mediante `AuthService`.

--- a/nest.core.view.security/angular.json
+++ b/nest.core.view.security/angular.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "nest-core-view-security": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "browser": "src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "public"
+              }
+            ],
+            "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "4kB",
+                  "maximumError": "8kB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "nest-core-view-security:build:production"
+            },
+            "development": {
+              "buildTarget": "nest-core-view-security:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
+            "tsConfig": "tsconfig.spec.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "public"
+              }
+            ],
+            "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.scss"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/nest.core.view.security/package.json
+++ b/nest.core.view.security/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "nest-core-view-security",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^21.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/compiler": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/forms": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
+    "@angular/platform-browser-dynamic": "^21.0.0",
+    "@angular/router": "^21.0.0",
+    "bootstrap": "^5.3.8",
+    "rxjs": "^7.8.2",
+    "tslib": "^2.8.1",
+    "zone.js": "^0.15.1"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^21.0.0",
+    "@angular/cli": "^21.0.0",
+    "@angular/compiler-cli": "^21.0.0",
+    "@types/jasmine": "~5.1.9",
+    "jasmine-core": "~5.12.1",
+    "karma": "~6.4.4",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.1",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.9.3"
+  }
+}

--- a/nest.core.view.security/src/app/app.component.ts
+++ b/nest.core.view.security/src/app/app.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet],
+  template: '<router-outlet></router-outlet>'
+})
+export class AppComponent {}

--- a/nest.core.view.security/src/app/app.routes.ts
+++ b/nest.core.view.security/src/app/app.routes.ts
@@ -1,0 +1,14 @@
+import { Routes } from '@angular/router';
+
+import { HomeComponent } from './features/home/home.component';
+
+export const appRoutes: Routes = [
+  {
+    path: '',
+    component: HomeComponent
+  },
+  {
+    path: '**',
+    redirectTo: ''
+  }
+];

--- a/nest.core.view.security/src/app/core/models/login-request.model.ts
+++ b/nest.core.view.security/src/app/core/models/login-request.model.ts
@@ -1,0 +1,4 @@
+export interface LoginRequest {
+  username: string;
+  password: string;
+}

--- a/nest.core.view.security/src/app/core/models/login-response.model.ts
+++ b/nest.core.view.security/src/app/core/models/login-response.model.ts
@@ -1,0 +1,4 @@
+export interface LoginResponse {
+  token: string;
+  expiresIn?: number;
+}

--- a/nest.core.view.security/src/app/core/services/auth.service.ts
+++ b/nest.core.view.security/src/app/core/services/auth.service.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+import { LoginRequest } from '../models/login-request.model';
+import { LoginResponse } from '../models/login-response.model';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.securityApiUrl;
+
+  login(payload: LoginRequest): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.baseUrl}/auth/login`, payload);
+  }
+}

--- a/nest.core.view.security/src/app/features/auth/login.component.html
+++ b/nest.core.view.security/src/app/features/auth/login.component.html
@@ -1,0 +1,29 @@
+<form [formGroup]="loginForm" (ngSubmit)="submit()" class="mx-auto" style="max-width: 420px;">
+  <div class="mb-3">
+    <label for="username" class="form-label">Usuario</label>
+    <input id="username" type="text" class="form-control" formControlName="username" autocomplete="username" />
+    @if (loginForm.controls.username.touched && loginForm.controls.username.invalid) {
+      <div class="text-danger small mt-1">Ingresa un usuario válido (mínimo 3 caracteres).</div>
+    }
+  </div>
+
+  <div class="mb-3">
+    <label for="password" class="form-label">Contraseña</label>
+    <input id="password" type="password" class="form-control" formControlName="password" autocomplete="current-password" />
+    @if (loginForm.controls.password.touched && loginForm.controls.password.invalid) {
+      <div class="text-danger small mt-1">Ingresa una contraseña válida (mínimo 6 caracteres).</div>
+    }
+  </div>
+
+  <button type="submit" class="btn btn-primary w-100" [disabled]="isSubmitting()">
+    @if (isSubmitting()) { Entrando... } @else { Ingresar }
+  </button>
+
+  @if (errorMessage()) {
+    <div class="alert alert-danger mt-3 mb-0" role="alert">{{ errorMessage() }}</div>
+  }
+
+  @if (successMessage()) {
+    <div class="alert alert-success mt-3 mb-0" role="alert">{{ successMessage() }}</div>
+  }
+</form>

--- a/nest.core.view.security/src/app/features/auth/login.component.ts
+++ b/nest.core.view.security/src/app/features/auth/login.component.ts
@@ -1,0 +1,49 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { AuthService } from '../../core/services/auth.service';
+import { LoginRequest } from '../../core/models/login-request.model';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  templateUrl: './login.component.html'
+})
+export class LoginComponent {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+
+  readonly isSubmitting = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+  readonly successMessage = signal<string | null>(null);
+
+  readonly loginForm = this.formBuilder.nonNullable.group({
+    username: ['', [Validators.required, Validators.minLength(3)]],
+    password: ['', [Validators.required, Validators.minLength(6)]]
+  });
+
+  submit(): void {
+    if (this.loginForm.invalid) {
+      this.loginForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    const credentials: LoginRequest = this.loginForm.getRawValue();
+
+    this.authService.login(credentials).subscribe({
+      next: () => {
+        this.successMessage.set('Inicio de sesión exitoso.');
+        this.isSubmitting.set(false);
+      },
+      error: () => {
+        this.errorMessage.set('No se pudo iniciar sesión. Verifica tus credenciales.');
+        this.isSubmitting.set(false);
+      }
+    });
+  }
+}

--- a/nest.core.view.security/src/app/features/home/home.component.html
+++ b/nest.core.view.security/src/app/features/home/home.component.html
@@ -1,0 +1,12 @@
+<main class="container py-5">
+  <section class="row justify-content-center">
+    <div class="col-12 col-lg-8">
+      <div class="card shadow-sm">
+        <div class="card-body p-4 p-md-5">
+          <h1 class="display-6 text-center mb-4">INDEX</h1>
+          <app-login></app-login>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>

--- a/nest.core.view.security/src/app/features/home/home.component.scss
+++ b/nest.core.view.security/src/app/features/home/home.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/nest.core.view.security/src/app/features/home/home.component.ts
+++ b/nest.core.view.security/src/app/features/home/home.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+import { LoginComponent } from '../auth/login.component';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [LoginComponent],
+  templateUrl: './home.component.html',
+  styleUrl: './home.component.scss'
+})
+export class HomeComponent {}

--- a/nest.core.view.security/src/environments/environment.ts
+++ b/nest.core.view.security/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  securityApiUrl: 'https://nest.core.security'
+};

--- a/nest.core.view.security/src/index.html
+++ b/nest.core.view.security/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Nest Core View Security</title>
+    <base href="/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/nest.core.view.security/src/main.ts
+++ b/nest.core.view.security/src/main.ts
@@ -1,0 +1,10 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+
+import { AppComponent } from './app/app.component';
+import { appRoutes } from './app/app.routes';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideHttpClient(), provideRouter(appRoutes)]
+}).catch((error: unknown) => console.error(error));

--- a/nest.core.view.security/src/styles.scss
+++ b/nest.core.view.security/src/styles.scss
@@ -1,0 +1,7 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  background-color: #f8f9fa;
+}

--- a/nest.core.view.security/tsconfig.app.json
+++ b/nest.core.view.security/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/nest.core.view.security/tsconfig.json
+++ b/nest.core.view.security/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": false,
+    "experimentalDecorators": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": [
+      "ES2022",
+      "dom"
+    ]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/nest.core.view.security/tsconfig.spec.json
+++ b/nest.core.view.security/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Crear un módulo frontend en `nest.core.view.security` que exponga una página principal con el texto `INDEX` y un formulario de login conectado al servicio de seguridad central (`nest.core.security`).
- Usar Angular 21 con componentes standalone y Bootstrap 5.3 siguiendo buenas prácticas de estructura y tipado para facilitar su integración y despliegue.

### Description
- Añadido esqueleto de proyecto Angular con archivos de configuración clave (`package.json`, `angular.json`, `tsconfig*.json`, `.editorconfig`, `.gitignore`, `README.md`).
- Implementados componentes standalone `AppComponent`, `HomeComponent` (muestra `INDEX`) y `LoginComponent` (formulario reactivo con validaciones y estado de envío). 
- Añadido `AuthService` que usa `HttpClient` y modelos tipados `LoginRequest`/`LoginResponse`, y centralización de la URL de la API en `src/environments/environment.ts` apuntando a `https://nest.core.security`.
- Integrado Bootstrap 5.3 en la configuración global de estilos (`angular.json`) y estilos base en `src/styles.scss`.

### Testing
- Ejecutado `npx -y @angular/cli@21 new` para crear scaffold inicial, pero falló por restricción de acceso al registro npm (`403 Forbidden`).
- Ejecutado `npm install` en el directorio del proyecto, que falló por el mismo error de acceso al registry npm (`403 Forbidden`).
- Ejecutado `ng version`, que no respondió porque `ng` no está disponible en el entorno; por tanto no se pudieron ejecutar builds o tests de Angular en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4de017d0c8333a853862e9796ec34)