### PR TITLE
refactor(view.security): separar templates y estilos por componente

### DIFF
--- a/nest.core.view.security/src/app/app.component.html
+++ b/nest.core.view.security/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/nest.core.view.security/src/app/app.component.scss
+++ b/nest.core.view.security/src/app/app.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/nest.core.view.security/src/app/app.component.ts
+++ b/nest.core.view.security/src/app/app.component.ts
@@ -4,7 +4,8 @@ import { RouterOutlet } from '@angular/router';
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet],
-  template: '<router-outlet></router-outlet>',
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {}

--- a/nest.core.view.security/src/app/features/auth/pages/login-page.component.html
+++ b/nest.core.view.security/src/app/features/auth/pages/login-page.component.html
@@ -1,0 +1,55 @@
+<section class="container d-flex min-vh-100 align-items-center justify-content-center py-5">
+  <article class="card shadow-sm border-0 login-card w-100">
+    <div class="card-body p-4 p-md-5">
+      <header class="mb-4 text-center">
+        <h1 class="h3 mb-1">Iniciar sesión</h1>
+        <p class="text-muted mb-0">Accede con tus credenciales de Security.</p>
+      </header>
+
+      <form [formGroup]="loginForm" (ngSubmit)="submit()" novalidate>
+        <div class="mb-3">
+          <label for="email" class="form-label">Correo electrónico</label>
+          <input
+            id="email"
+            type="email"
+            class="form-control"
+            formControlName="email"
+            [class.is-invalid]="showError('email')"
+            autocomplete="username"
+          />
+          @if (showError('email')) {
+            <div class="invalid-feedback">Ingresa un correo válido.</div>
+          }
+        </div>
+
+        <div class="mb-3">
+          <label for="password" class="form-label">Contraseña</label>
+          <input
+            id="password"
+            type="password"
+            class="form-control"
+            formControlName="password"
+            [class.is-invalid]="showError('password')"
+            autocomplete="current-password"
+          />
+          @if (showError('password')) {
+            <div class="invalid-feedback">La contraseña es obligatoria.</div>
+          }
+        </div>
+
+        @if (hasError()) {
+          <div class="alert alert-danger py-2" role="alert">
+            No se pudo iniciar sesión. Verifica tus credenciales.
+          </div>
+        }
+
+        <button class="btn btn-primary w-100" type="submit" [disabled]="isSubmitting()">
+          @if (isSubmitting()) {
+            <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
+          }
+          Entrar
+        </button>
+      </form>
+    </div>
+  </article>
+</section>

--- a/nest.core.view.security/src/app/features/auth/pages/login-page.component.ts
+++ b/nest.core.view.security/src/app/features/auth/pages/login-page.component.ts
@@ -7,63 +7,7 @@ import { AuthService } from '../../../core/auth/auth.service';
 @Component({
   selector: 'app-login-page',
   imports: [ReactiveFormsModule],
-  template: `
-    <section class="container d-flex min-vh-100 align-items-center justify-content-center py-5">
-      <article class="card shadow-sm border-0 login-card w-100">
-        <div class="card-body p-4 p-md-5">
-          <header class="mb-4 text-center">
-            <h1 class="h3 mb-1">Iniciar sesión</h1>
-            <p class="text-muted mb-0">Accede con tus credenciales de Security.</p>
-          </header>
-
-          <form [formGroup]="loginForm" (ngSubmit)="submit()" novalidate>
-            <div class="mb-3">
-              <label for="email" class="form-label">Correo electrónico</label>
-              <input
-                id="email"
-                type="email"
-                class="form-control"
-                formControlName="email"
-                [class.is-invalid]="showError('email')"
-                autocomplete="username"
-              />
-              @if (showError('email')) {
-                <div class="invalid-feedback">Ingresa un correo válido.</div>
-              }
-            </div>
-
-            <div class="mb-3">
-              <label for="password" class="form-label">Contraseña</label>
-              <input
-                id="password"
-                type="password"
-                class="form-control"
-                formControlName="password"
-                [class.is-invalid]="showError('password')"
-                autocomplete="current-password"
-              />
-              @if (showError('password')) {
-                <div class="invalid-feedback">La contraseña es obligatoria.</div>
-              }
-            </div>
-
-            @if (hasError()) {
-              <div class="alert alert-danger py-2" role="alert">
-                No se pudo iniciar sesión. Verifica tus credenciales.
-              </div>
-            }
-
-            <button class="btn btn-primary w-100" type="submit" [disabled]="isSubmitting()">
-              @if (isSubmitting()) {
-                <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
-              }
-              Entrar
-            </button>
-          </form>
-        </div>
-      </article>
-    </section>
-  `,
+  templateUrl: './login-page.component.html',
   styleUrl: './login-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/nest.core.view.security/src/app/features/main/pages/main-page.component.html
+++ b/nest.core.view.security/src/app/features/main/pages/main-page.component.html
@@ -1,0 +1,3 @@
+<section class="text-center py-5">
+  <h1 class="display-5 fw-bold">INDEX</h1>
+</section>

--- a/nest.core.view.security/src/app/features/main/pages/main-page.component.scss
+++ b/nest.core.view.security/src/app/features/main/pages/main-page.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/nest.core.view.security/src/app/features/main/pages/main-page.component.ts
+++ b/nest.core.view.security/src/app/features/main/pages/main-page.component.ts
@@ -2,11 +2,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'app-main-page',
-  template: `
-    <section class="text-center py-5">
-      <h1 class="display-5 fw-bold">INDEX</h1>
-    </section>
-  `,
+  templateUrl: './main-page.component.html',
+  styleUrl: './main-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MainPageComponent {}


### PR DESCRIPTION
### Motivation
- Separar los templates y estilos inline en archivos por componente para mejorar la mantenibilidad y permitir edición y pruebas más simples. 
- Homogeneizar la estructura de los componentes (`AppComponent`, `LoginPageComponent`, `MainPageComponent`) para que usen archivos externos de template y estilo. 

### Description
- Moví el template inline de `LoginPageComponent` a `nest.core.view.security/src/app/features/auth/pages/login-page.component.html` y actualicé el componente para usar `templateUrl` y su `styleUrl`. 
- Moví el template inline de `MainPageComponent` a `nest.core.view.security/src/app/features/main/pages/main-page.component.html` y añadí `nest.core.view.security/src/app/features/main/pages/main-page.component.scss`. 
- Moví el template inline de `AppComponent` a `nest.core.view.security/src/app/app.component.html` y añadí `nest.core.view.security/src/app/app.component.scss`, además de actualizar `app.component.ts` para usar `templateUrl` y `styleUrl`. 

### Testing
- Ejecuté `npm run build` en `nest.core.view.security` pero la validación falló por el entorno por falta de Angular CLI (`sh: 1: ng: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5049dd37c8333be87b9e6c893263f)