### PR TITLE
feat(view-security): mantenimiento de Usuarios con DevExpress Custom Data Source

### DIFF
--- a/nest.core.view.security/angular.json
+++ b/nest.core.view.security/angular.json
@@ -36,7 +36,7 @@
             "styles": [
               "src/styles.scss",
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
-              "node_modules/devextreme/dist/css/dx.light.css"
+              "node_modules/devextreme/dist/css/dx.light.compact.css"
             ],
             "scripts": [
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"

--- a/nest.core.view.security/angular.json
+++ b/nest.core.view.security/angular.json
@@ -35,7 +35,8 @@
             ],
             "styles": [
               "src/styles.scss",
-              "node_modules/bootstrap/dist/css/bootstrap.min.css"
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "node_modules/devextreme/dist/css/dx.light.css"
             ],
             "scripts": [
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"

--- a/nest.core.view.security/package-lock.json
+++ b/nest.core.view.security/package-lock.json
@@ -17,7 +17,10 @@
         "@angular/platform-browser-dynamic": "21.2.9",
         "@angular/router": "21.2.9",
         "bootstrap": "^5.3.8",
+        "devextreme": "^25.1.6",
+        "devextreme-angular": "^25.1.6",
         "rxjs": "^7.8.1",
+        "sweetalert2": "^11.26.24",
         "tslib": "^2.8.0",
         "zone.js": "^0.16.0"
       },
@@ -2368,7 +2371,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2421,6 +2423,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@devexpress/utils": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@devexpress/utils/-/utils-1.4.8.tgz",
+      "integrity": "sha512-XVqyeYjqWjbcAUOxaUc6f93MATuVyFE2eec10Qm7X3/QLkKPBh2cJt5OOw4bkW4fC8SG8NZwjVITt08Tr+CXpQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "tslib": "2.3.1"
+      }
+    },
+    "node_modules/@devexpress/utils/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "license": "0BSD"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
@@ -2857,7 +2874,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2868,7 +2884,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2879,7 +2894,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2900,14 +2914,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3972,6 +3984,16 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.4.tgz",
@@ -4661,7 +4683,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4678,7 +4699,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -4968,6 +4988,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
@@ -5030,6 +5070,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -5152,6 +5203,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -5454,6 +5529,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -5486,7 +5570,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5499,7 +5582,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5673,6 +5755,17 @@
         "webpack": "^5.1.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
@@ -5691,7 +5784,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -5833,6 +5925,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5876,6 +5974,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5932,6 +6042,713 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/devexpress-diagram": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/devexpress-diagram/-/devexpress-diagram-2.2.25.tgz",
+      "integrity": "sha512-gcj+7AyH6HEzURTbexqbIciCGNFOAbypM6Gi2OuyvtQNR04WQCYozh8C3H0kLfHBNpRm2nEyjJWpV9MWThM8hA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@devexpress/utils": "^1.4.6",
+        "es6-object-assign": "^1.1.0"
+      }
+    },
+    "node_modules/devexpress-gantt": {
+      "version": "4.1.67",
+      "resolved": "https://registry.npmjs.org/devexpress-gantt/-/devexpress-gantt-4.1.67.tgz",
+      "integrity": "sha512-sO9zNsOUk4lasHaUqjbDMUgi3CGO2t5OkGPWZH1tCthzSePSYAbfgYL86F214+aB/a+GYU87vXOAWyju0rh5EA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@devexpress/utils": "^1.4.7",
+        "tslib": "2.3.1"
+      }
+    },
+    "node_modules/devexpress-gantt/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "license": "0BSD"
+    },
+    "node_modules/devextreme": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/devextreme/-/devextreme-25.2.6.tgz",
+      "integrity": "sha512-wshGlQtHXLj5vPku1WhwXHivCOzFqYnWjr4pLPGvT7RGpJgN9qhEK9XTQ5MtfILxyLwnONKD2sVteg2ZHMwK5Q==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@preact/signals-core": "^1.8.0",
+        "devexpress-diagram": "2.2.25",
+        "devexpress-gantt": "4.1.67",
+        "devextreme-quill": "1.7.8",
+        "inferno": "^8.2.3",
+        "inferno-create-element": "^8.2.3",
+        "inferno-hydrate": "^8.2.3",
+        "jszip": "^3.10.1",
+        "rrule": "^2.7.1",
+        "unplugin": "^3.0.0"
+      },
+      "bin": {
+        "devextreme-bundler": "bin/bundler.js",
+        "devextreme-bundler-init": "bin/bundler-init.js",
+        "devextreme-license": "bin/devextreme-license.js"
+      }
+    },
+    "node_modules/devextreme-angular": {
+      "version": "25.2.6",
+      "resolved": "https://registry.npmjs.org/devextreme-angular/-/devextreme-angular-25.2.6.tgz",
+      "integrity": "sha512-acPPDiJ65Vj0sXufilh26IyvNjnJWQGEWf1Swr5armn3CDsKWCz0duHJvxts4DQMw/mqvZuHN6HpgmXkzf/l0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/schematics": "~19.2.19",
+        "devextreme-schematics": "*",
+        "inferno-server": "^8.2.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "@angular/forms": ">=19.0.0",
+        "devextreme": "25.2.6"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/@angular-devkit/core": {
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.24.tgz",
+      "integrity": "sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/@angular-devkit/schematics": {
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.24.tgz",
+      "integrity": "sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "19.2.24",
+        "jsonc-parser": "3.3.1",
+        "magic-string": "0.30.17",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/devextreme-angular/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-angular/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-quill": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/devextreme-quill/-/devextreme-quill-1.7.8.tgz",
+      "integrity": "sha512-0UcJNc5crQ6eJTEteizRW9qv0xJqk1nnmX0xleI3IgHKS+CV3Vk7Xi+VOlEkFJDFiybRdhVse4cyFHslc86mGQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "core-js": "^3.34.0",
+        "eventemitter3": "^4.0.7",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.merge": "^4.6.2",
+        "parchment": "^2.0.1",
+        "quill-delta": "^5.0.0"
+      }
+    },
+    "node_modules/devextreme-schematics": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/devextreme-schematics/-/devextreme-schematics-1.14.2.tgz",
+      "integrity": "sha512-kT2Gf1XpQeG72x4q/SLiFvTrD2wswyrojSkxLWlWwRQZ3kGauFRVg3CPu6s2zZ1eJc705N8W38fwgEgN+nONnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "^19.2.22",
+        "@angular-devkit/schematics": "^19.2.22",
+        "@schematics/angular": "^19.2.22",
+        "parse5": "^7.3.0",
+        "picomatch": "^4.0.3"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/@angular-devkit/core": {
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.24.tgz",
+      "integrity": "sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.4",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/@angular-devkit/schematics": {
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.24.tgz",
+      "integrity": "sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "19.2.24",
+        "jsonc-parser": "3.3.1",
+        "magic-string": "0.30.17",
+        "ora": "5.4.1",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/@schematics/angular": {
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.2.24.tgz",
+      "integrity": "sha512-RGHb7ebUQTOxtWfNcBXCzDog8LwJzvVp3/BptEI+78M+tCaBJM6BAS2vrDphJRjVbjV3DTwZcmlNRqCHJeSknA==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": "19.2.24",
+        "@angular-devkit/schematics": "19.2.24",
+        "jsonc-parser": "3.3.1"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/devextreme-schematics/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devextreme-schematics/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -6182,6 +6999,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -6325,7 +7148,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -6435,14 +7257,18 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6784,7 +7610,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7071,6 +7896,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
@@ -7098,6 +7943,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
@@ -7122,11 +7973,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inferno": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/inferno/-/inferno-8.2.3.tgz",
+      "integrity": "sha512-LMeRlCe+RlXw8kHCLyOWRk2PsZ3Fo4jkESyAR1g4FfPT48N78i11YhTVXW2ukCx5MFjv+qrfa73JzJWU9sg4CQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.2",
+        "inferno-vnode-flags": "8.2.3",
+        "opencollective-postinstall": "^2.0.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/inferno"
+      }
+    },
+    "node_modules/inferno-create-element": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/inferno-create-element/-/inferno-create-element-8.2.3.tgz",
+      "integrity": "sha512-YEwX4OiFlgeTutvE16uCGxkaSVwZ1DklpAPX8okjVsGaLIWQrM8QIQFxn3mTLWSu70Uea+afQfKL5wE4hxn39Q==",
+      "license": "MIT",
+      "dependencies": {
+        "inferno": "8.2.3"
+      }
+    },
+    "node_modules/inferno-hydrate": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/inferno-hydrate/-/inferno-hydrate-8.2.3.tgz",
+      "integrity": "sha512-AyCiswnjYg7D9veJdjiQg06Npp0/iXKhwOm2hjoY3cjadT3fIdz2XtDElLB7imU4icuJ3xOmXA8FgIfnSJfHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inferno": "8.2.3"
+      }
+    },
+    "node_modules/inferno-server": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/inferno-server/-/inferno-server-8.2.3.tgz",
+      "integrity": "sha512-swaDCaTYPplKwcBDbveu7xKIAooLXOOdfRoETTCIZwKyfKBGR3JnqsrwcL6miFR8TG6CNibvYKG8eSYHzkoA4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "inferno": "8.2.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inferno-vnode-flags": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/inferno-vnode-flags/-/inferno-vnode-flags-8.2.3.tgz",
+      "integrity": "sha512-dfC0MIwFv9PCbZCUsuk9ISejFS3fKJODC0rZ/LjxxzE+OrCk+PMwPLsUnGU6O9/jbBnPACVz1BkACDf5LWgU5Q==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -7388,7 +8290,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -7517,7 +8418,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
@@ -7544,7 +8444,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonparse": {
@@ -7556,6 +8455,48 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",
@@ -7669,6 +8610,15 @@
         "webpack-sources": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7808,11 +8758,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -8120,6 +9089,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-function": {
@@ -8778,6 +9756,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
     "node_modules/ora": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
@@ -8913,6 +9900,18 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parchment": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-2.0.1.tgz",
+      "integrity": "sha512-VBKrlEoZCBD+iwoeag0QTtY1Cti+Ma4nLpVYcc/uus/wHhMsPOi5InH3RL1s4aekahPZpabcS2ToKyGf7RMH/g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -9116,7 +10115,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9383,7 +10381,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/promise-retry": {
@@ -9458,6 +10455,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9488,7 +10499,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -9589,7 +10599,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9804,6 +10813,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -9830,7 +10848,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10209,6 +11226,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -10615,7 +11638,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -10681,6 +11703,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.26.24",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.26.24.tgz",
+      "integrity": "sha512-SLgukW4wicewpW5VOukSXY5Z6DL/z7HCOK2ODSjmQPiSphCN8gJAmh9npoceXOtBRNoDN0xIz+zHYthtfiHmjg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/tapable": {
@@ -11016,6 +12048,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -11051,7 +12097,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -11191,6 +12236,15 @@
       "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/weak-lru-cache": {
@@ -11830,6 +12884,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/nest.core.view.security/package.json
+++ b/nest.core.view.security/package.json
@@ -24,6 +24,7 @@
     "devextreme": "^25.1.6",
     "devextreme-angular": "^25.1.6",
     "rxjs": "^7.8.1",
+    "sweetalert2": "^11.26.24",
     "tslib": "^2.8.0",
     "zone.js": "^0.16.0"
   },

--- a/nest.core.view.security/package.json
+++ b/nest.core.view.security/package.json
@@ -21,6 +21,8 @@
     "@angular/platform-browser-dynamic": "21.2.9",
     "@angular/router": "21.2.9",
     "bootstrap": "^5.3.8",
+    "devextreme": "^25.1.6",
+    "devextreme-angular": "^25.1.6",
     "rxjs": "^7.8.1",
     "tslib": "^2.8.0",
     "zone.js": "^0.16.0"

--- a/nest.core.view.security/src/app/app.config.ts
+++ b/nest.core.view.security/src/app/app.config.ts
@@ -1,15 +1,14 @@
-import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, provideBrowserGlobalErrorListeners, Provider, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
-
 import { authInterceptor } from './core/auth/auth.interceptor';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(appRoutes), 
     provideHttpClient(withInterceptors([authInterceptor])),
-    provideRouter(appRoutes),
   ],
 };

--- a/nest.core.view.security/src/app/app.routes.ts
+++ b/nest.core.view.security/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { authGuard } from './core/auth/auth.guard';
 import { ShellComponent } from './core/layout/shell/shell.component';
 import { LoginPageComponent } from './features/auth/pages/login-page.component';
 import { MainPageComponent } from './features/main/pages/main-page.component';
+import { UsuariosPageComponent } from './features/usuarios/pages/usuarios-page.component';
 
 export const appRoutes: Routes = [
   {
@@ -20,6 +21,11 @@ export const appRoutes: Routes = [
         path: '',
         component: MainPageComponent,
         title: 'Index',
+      },
+      {
+        path: 'usuarios',
+        component: UsuariosPageComponent,
+        title: 'Usuarios',
       },
     ],
   },

--- a/nest.core.view.security/src/app/core/auth/auth.interceptor.ts
+++ b/nest.core.view.security/src/app/core/auth/auth.interceptor.ts
@@ -1,21 +1,29 @@
-import { HttpInterceptorFn } from '@angular/common/http';
-import { inject } from '@angular/core';
-
-import { AuthService } from '../services/auth.service';
+import { HttpErrorResponse, HttpInterceptorFn } from "@angular/common/http";
+import { AuthService } from "../services/auth.service";
+import { inject } from "@angular/core";
+import { Router } from "@angular/router";
+import { catchError, throwError } from "rxjs";
 
 export const authInterceptor: HttpInterceptorFn = (request, next) => {
   const authService = inject(AuthService);
+  const router = inject(Router);
   const token = authService.getToken();
 
-  if (!token) {
-    return next(request);
-  }
+  const authRequest = token
+    ? request.clone({
+        setHeaders: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+    : request;
 
-  return next(
-    request.clone({
-      setHeaders: {
-        Authorization: `Bearer ${token}`,
-      },
-    }),
+  return next(authRequest).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        authService.logout();
+        router.navigate(['/login']);
+      }
+      return throwError(() => error);
+    })
   );
 };

--- a/nest.core.view.security/src/app/core/entities/security-user.entity.ts
+++ b/nest.core.view.security/src/app/core/entities/security-user.entity.ts
@@ -6,6 +6,7 @@ export interface SecurityUserEntity {
   normalizedEmail: string;
   emailConfirmed: boolean;
   passwordHash: string;
+  password: string;
   securityStamp: string;
   concurrencyStamp: string;
   phoneNumber: string | null;
@@ -24,4 +25,9 @@ export interface SecurityUserCreatePayload {
 
 export interface SecurityUserUpdatePayload extends SecurityUserCreatePayload {
   id: string;
+}
+
+export interface SecurityUserResetPwPayload {
+  id: string;
+  password: string;
 }

--- a/nest.core.view.security/src/app/core/entities/security-user.entity.ts
+++ b/nest.core.view.security/src/app/core/entities/security-user.entity.ts
@@ -1,0 +1,27 @@
+export interface SecurityUserEntity {
+  id: string;
+  userName: string;
+  normalizedUserName: string;
+  email: string;
+  normalizedEmail: string;
+  emailConfirmed: boolean;
+  passwordHash: string;
+  securityStamp: string;
+  concurrencyStamp: string;
+  phoneNumber: string | null;
+  phoneNumberConfirmed: boolean;
+  twoFactorEnabled: boolean;
+  lockoutEnd: string | null;
+  lockoutEnabled: boolean;
+  accessFailedCount: number;
+}
+
+export interface SecurityUserCreatePayload {
+  email: string;
+  password: string;
+  phoneNumber: string;
+}
+
+export interface SecurityUserUpdatePayload extends SecurityUserCreatePayload {
+  id: string;
+}

--- a/nest.core.view.security/src/app/core/services/auth.service.ts
+++ b/nest.core.view.security/src/app/core/services/auth.service.ts
@@ -29,9 +29,6 @@ export class AuthService {
         this.setTokenData(JSON.stringify(response));
       }),
       map((data) => true),
-      catchError((ex) => {
-        return throwError(() => ex);
-      }),
     );
     return result;
   }

--- a/nest.core.view.security/src/app/core/services/menu.service.ts
+++ b/nest.core.view.security/src/app/core/services/menu.service.ts
@@ -13,17 +13,7 @@ export class MenuService {
         children: [
           {
             label: 'Usuarios',
-            children: [
-              {
-                label: 'Perfiles',
-                children: [
-                  {
-                    label: 'Permisos (Nivel 4)',
-                    route: '/',
-                  },
-                ],
-              },
-            ],
+            route: '/usuarios',
           },
           {
             label: 'Roles',

--- a/nest.core.view.security/src/app/core/services/nestUtils.ts
+++ b/nest.core.view.security/src/app/core/services/nestUtils.ts
@@ -1,0 +1,87 @@
+import { firstValueFrom } from "rxjs";
+import Swal, { SweetAlertOptions } from "sweetalert2";
+
+export class NestUtils {
+    public static formatValidationErrors(error: any): string {
+        if (!error) {
+            return 'Ha ocurrido un error desconocido.';
+        }
+        if(error.error && error.error.errors) {
+            const agrupados = error.error.errors.reduce((acc: any, current: any) => {
+                if (!acc[current.field]) {
+                    acc[current.field] = [];
+                }
+                acc[current.field].push(current.message);
+                return acc;
+            }, {});
+            console.log('Agrupados:', agrupados);
+            let errorMessages = '';
+            Object.keys(agrupados).forEach(campo => {
+                errorMessages += `${campo}: \n\r`;
+                errorMessages += agrupados[campo].map((msg: string) => `\t\t\t > ${msg}`).join('\n\r');
+            });
+            return errorMessages;
+        }
+        if(error.error && error.error.detail) {
+            return error.error.detail;
+        }
+
+        if(error && error.message) {
+            return `${error.message}`;
+        }
+        return 'Ha ocurrido un error desconocido.';
+    }
+
+    public static async showConfirmationDialog(options: any) {
+        options.confirmTitle = options?.confirmTitle ?? 'Correcto';
+        options.confirmText = options?.confirmText ?? 'La acción se realizó con éxito';
+        options.confirmIcon = options?.confirmIcon ?? 'success';
+        options.funtionToExecute = options?.funtionToExecute ?? (() => {});
+
+        return new Promise<void>(async (resolve, reject) => {
+            const result = await Swal.fire({
+                title: '¿Estás seguro?',
+                text: 'No podrás revertir esta acción',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Sí',
+                cancelButtonText: 'Cancelar',
+                showLoaderOnConfirm: true,
+                preConfirm: async () => {
+                    let resultCall = null;
+                    try {
+                        if(options.funtionToExecute) resultCall = await firstValueFrom(options.funtionToExecute());
+                    } catch (error) {
+                        const errorMessage = this.formatValidationErrors(error);
+                        Swal.showValidationMessage(errorMessage);
+                    }
+                    return resultCall;
+                },
+                allowOutsideClick: () => !Swal.isLoading(),
+                customClass: {
+                    container: 'swal-on-top',
+                },
+                ...options
+            });
+            if (result.isConfirmed) {
+                let textResult = '';
+                if(typeof options.confirmText === 'string') {
+                    textResult = options.confirmText;
+                } else if(options.confirmText != undefined) {
+                    textResult = await options.confirmText(result.value);
+                }
+                await Swal.fire({
+                    title: options.confirmTitle, 
+                    text: textResult, 
+                    icon: options.confirmIcon,
+                    customClass: {
+                        container: 'swal-on-top',
+                    },
+                });
+                resolve(result.value);
+            } else {
+                reject('Acción cancelada por el usuario');
+            }
+        });
+    }
+}

--- a/nest.core.view.security/src/app/core/services/security-user.service.ts
+++ b/nest.core.view.security/src/app/core/services/security-user.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { SecurityUserCreatePayload, SecurityUserEntity, SecurityUserUpdatePayload } from '../entities/security-user.entity';
+import { environment } from '@environment/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SecurityUserService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly endpoint = `${environment.apiBaseUrl}/security/Usuario`;
+
+  getAll(): Observable<SecurityUserEntity[]> {
+    return this.httpClient.get<SecurityUserEntity[]>(this.endpoint);
+  }
+
+  getById(id: string): Observable<SecurityUserEntity> {
+    return this.httpClient.get<SecurityUserEntity>(`${this.endpoint}/${id}`);
+  }
+
+  create(payload: SecurityUserCreatePayload): Observable<SecurityUserEntity> {
+    return this.httpClient.post<SecurityUserEntity>(this.endpoint, payload);
+  }
+
+  update(payload: SecurityUserUpdatePayload): Observable<SecurityUserEntity> {
+    return this.httpClient.put<SecurityUserEntity>(`${this.endpoint}/${payload.id}`, payload);
+  }
+
+  delete(id: string): Observable<boolean> {
+    return this.httpClient.delete<boolean>(`${this.endpoint}/${id}`);
+  }
+}

--- a/nest.core.view.security/src/app/core/services/security-user.service.ts
+++ b/nest.core.view.security/src/app/core/services/security-user.service.ts
@@ -2,8 +2,9 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { SecurityUserCreatePayload, SecurityUserEntity, SecurityUserUpdatePayload } from '../entities/security-user.entity';
+import { SecurityUserCreatePayload, SecurityUserEntity, SecurityUserResetPwPayload, SecurityUserUpdatePayload } from '../entities/security-user.entity';
 import { environment } from '@environment/environment';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
 
 @Injectable({
   providedIn: 'root',
@@ -14,6 +15,10 @@ export class SecurityUserService {
 
   getAll(): Observable<SecurityUserEntity[]> {
     return this.httpClient.get<SecurityUserEntity[]>(this.endpoint);
+  }
+
+  getByFilter(loadOptions: LoadOptions): Observable<LoadResult<SecurityUserEntity[]>> {
+    return this.httpClient.post<LoadResult<SecurityUserEntity[]>>(`${this.endpoint}/filter`, loadOptions);
   }
 
   getById(id: string): Observable<SecurityUserEntity> {
@@ -30,5 +35,9 @@ export class SecurityUserService {
 
   delete(id: string): Observable<boolean> {
     return this.httpClient.delete<boolean>(`${this.endpoint}/${id}`);
+  }
+
+  resetPw(payload: SecurityUserResetPwPayload): Observable<SecurityUserEntity> {
+    return this.httpClient.put<SecurityUserEntity>(`${this.endpoint}/resetpw`, payload);
   }
 }

--- a/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.html
+++ b/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.html
@@ -1,0 +1,50 @@
+<section class="card shadow-sm border-0">
+  <header class="card-header bg-white border-bottom">
+    <h5 class="mb-0">Mantenimiento de Usuarios</h5>
+  </header>
+
+  <div class="card-body">
+    @if (errorMessage()) {
+      <div class="alert alert-danger" role="alert">
+        {{ errorMessage() }}
+      </div>
+    }
+
+    <dx-data-grid
+      class="usuarios-grid"
+      [dataSource]="userDataSource"
+      [showBorders]="true"
+      [rowAlternationEnabled]="true"
+      [remoteOperations]="false"
+      [columnAutoWidth]="true"
+    >
+      <dxo-search-panel [visible]="true" [highlightCaseSensitive]="false"></dxo-search-panel>
+      <dxo-filter-row [visible]="true"></dxo-filter-row>
+      <dxo-paging [pageSize]="10"></dxo-paging>
+      <dxo-pager [showPageSizeSelector]="true" [allowedPageSizes]="[10, 20, 50]" [showInfo]="true"></dxo-pager>
+      <dxo-editing
+        mode="popup"
+        [allowAdding]="true"
+        [allowUpdating]="true"
+        [allowDeleting]="true"
+        [useIcons]="true"
+      >
+        <dxo-popup title="Usuario" [showTitle]="true" [width]="700" [height]="520"></dxo-popup>
+        <dxo-form [colCount]="2">
+          <dxi-item dataField="email" [isRequired]="true"></dxi-item>
+          <dxi-item dataField="phoneNumber"></dxi-item>
+          <dxi-item dataField="passwordHash" [isRequired]="true" editorType="dxTextBox" [editorOptions]="{ mode: 'password' }"></dxi-item>
+        </dxo-form>
+      </dxo-editing>
+
+      <dxi-column dataField="id" caption="Id" [allowEditing]="false" [visible]="false"></dxi-column>
+      <dxi-column dataField="userName" caption="Usuario" [allowEditing]="false"></dxi-column>
+      <dxi-column dataField="email" caption="Correo" [validationRules]="[{ type: 'required' }, { type: 'email' }]"></dxi-column>
+      <dxi-column dataField="normalizedEmail" caption="Correo Normalizado" [allowEditing]="false"></dxi-column>
+      <dxi-column dataField="phoneNumber" caption="Teléfono"></dxi-column>
+      <dxi-column dataField="emailConfirmed" caption="Correo Confirmado" dataType="boolean" [allowEditing]="false"></dxi-column>
+      <dxi-column dataField="lockoutEnabled" caption="Bloqueo Habilitado" dataType="boolean" [allowEditing]="false"></dxi-column>
+      <dxi-column dataField="accessFailedCount" caption="Intentos Fallidos" dataType="number" [allowEditing]="false"></dxi-column>
+    </dx-data-grid>
+  </div>
+</section>

--- a/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.html
+++ b/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.html
@@ -4,12 +4,6 @@
   </header>
 
   <div class="card-body">
-    @if (errorMessage()) {
-      <div class="alert alert-danger" role="alert">
-        {{ errorMessage() }}
-      </div>
-    }
-
     <dx-data-grid
       class="usuarios-grid"
       [dataSource]="userDataSource"
@@ -17,9 +11,15 @@
       [rowAlternationEnabled]="true"
       [remoteOperations]="false"
       [columnAutoWidth]="true"
+      [selection]="{ mode: 'single' }"
+      (onEditorPreparing)="onEditorPreparing($event)"
+      [remoteOperations]="true"
+      [showRowLines]="true"
+      [rowAlternationEnabled]="true"
     >
       <dxo-search-panel [visible]="true" [highlightCaseSensitive]="false"></dxo-search-panel>
       <dxo-filter-row [visible]="true"></dxo-filter-row>
+      <dxo-data-grid-header-filter [visible]="true"></dxo-data-grid-header-filter>
       <dxo-paging [pageSize]="10"></dxo-paging>
       <dxo-pager [showPageSizeSelector]="true" [allowedPageSizes]="[10, 20, 50]" [showInfo]="true"></dxo-pager>
       <dxo-editing
@@ -29,22 +29,91 @@
         [allowDeleting]="true"
         [useIcons]="true"
       >
-        <dxo-popup title="Usuario" [showTitle]="true" [width]="700" [height]="520"></dxo-popup>
+      <dxo-popup title="Usuario" [showTitle]="true"></dxo-popup>
         <dxo-form [colCount]="2">
           <dxi-item dataField="email" [isRequired]="true"></dxi-item>
-          <dxi-item dataField="phoneNumber"></dxi-item>
-          <dxi-item dataField="passwordHash" [isRequired]="true" editorType="dxTextBox" [editorOptions]="{ mode: 'password' }"></dxi-item>
+          <dxi-item dataField="phoneNumber" [isRequired]="true"></dxi-item>
+          <dxi-item 
+            dataField="password" 
+            [isRequired]="false" 
+            editorType="dxTextBox" 
+            [editorOptions]="{ mode: 'password', inputAttr: { autocomplete: 'new-password' } }">
+          </dxi-item>
         </dxo-form>
       </dxo-editing>
 
       <dxi-column dataField="id" caption="Id" [allowEditing]="false" [visible]="false"></dxi-column>
+      <dxi-column dataField="password" caption="Contraseña" [allowEditing]="true" [visible]="false" [allowFiltering]="false"></dxi-column>
       <dxi-column dataField="userName" caption="Usuario" [allowEditing]="false"></dxi-column>
       <dxi-column dataField="email" caption="Correo" [validationRules]="[{ type: 'required' }, { type: 'email' }]"></dxi-column>
-      <dxi-column dataField="normalizedEmail" caption="Correo Normalizado" [allowEditing]="false"></dxi-column>
       <dxi-column dataField="phoneNumber" caption="Teléfono"></dxi-column>
       <dxi-column dataField="emailConfirmed" caption="Correo Confirmado" dataType="boolean" [allowEditing]="false"></dxi-column>
       <dxi-column dataField="lockoutEnabled" caption="Bloqueo Habilitado" dataType="boolean" [allowEditing]="false"></dxi-column>
       <dxi-column dataField="accessFailedCount" caption="Intentos Fallidos" dataType="number" [allowEditing]="false"></dxi-column>
+      <dxi-column type="buttons">
+      <dxi-button name="edit"></dxi-button>
+      <dxi-button name="delete"></dxi-button>
+
+      <dxi-button
+        hint="Cambiar contraseña"
+        icon="key"
+        [onClick]="onChangePasswordClick">
+      </dxi-button>
+    </dxi-column>
     </dx-data-grid>
+    <dx-popup
+      [visible]="showPasswordPopup()"
+      (visibleChange)="togglePasswordPopup($event)"
+      title="Cambiar contraseña"
+      [width]="'90vw'"
+      [height]="'auto'"
+      [maxWidth]="900"
+      [showCloseButton]="true"
+    >
+      <div *dxTemplate="let data of 'content'">
+        <dx-validation-group #validationGroup>
+          <div class="row">
+            <div class="col-md-6">
+              <label class="form-label">Nueva contraseña</label>
+              <dx-text-box
+                [(value)]="newPassword"
+                mode="password"
+                [inputAttr]="{ autocomplete: 'new-password', name: 'no-es-no-1' }"
+                placeholder="Nueva contraseña">
+                <dx-validator>
+                  <dxi-validation-rule type="required" message="La contraseña es obligatoria" />
+                </dx-validator>
+              </dx-text-box>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Confirmar contraseña</label>
+              <dx-text-box
+                [(value)]="confirmNewPassword"
+                mode="password"
+                [inputAttr]="{ autocomplete: 'new-password', name: 'no-es-no-2' }"
+                placeholder="Confirmar contraseña">
+                <dx-validator>
+                  <dxi-validation-rule type="required" message="Debes confirmar la contraseña" />
+                  <dxi-validation-rule type="compare" message="Las contraseñas no coinciden" [comparisonTarget]="() => this.newPassword" />
+                </dx-validator>
+              </dx-text-box>
+            </div>
+          </div>
+          <div class="mt-3 text-end">
+            <dx-button
+              text="Guardar"
+              type="success"
+              (onClick)="savePassword(validationGroup)">
+            </dx-button>
+            <dx-button
+              text="Cancelar"
+              type="normal"
+              class="ms-2"
+              (onClick)="this.closePasswordPopup()">
+            </dx-button>
+          </div>
+        </dx-validation-group>
+      </div>
+    </dx-popup>
   </div>
 </section>

--- a/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.scss
+++ b/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.scss
@@ -1,0 +1,3 @@
+.usuarios-grid {
+  width: 100%;
+}

--- a/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.ts
+++ b/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.ts
@@ -1,95 +1,123 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import CustomStore from 'devextreme/data/custom_store';
-import { DxDataGridModule } from 'devextreme-angular';
-
+import { 
+  DxDataGridModule, 
+  DxTextBoxComponent, 
+  DxButtonComponent, 
+  DxPopupComponent, 
+  DxValidatorComponent ,
+  DxValidationGroupComponent
+} from 'devextreme-angular';
 import { SecurityUserEntity } from '@app/core/entities/security-user.entity';
 import { SecurityUserService } from '@app/core/services/security-user.service';
+import { NestUtils } from '@app/core/services/nestUtils';
+import { DxDataGridTypes } from 'devextreme-angular/ui/data-grid';
+import { HttpErrorResponse } from '@angular/common/http';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
 
 @Component({
   selector: 'app-usuarios-page',
-  imports: [DxDataGridModule],
+  imports: [
+    DxDataGridModule, 
+    DxPopupComponent, 
+    DxTextBoxComponent, 
+    DxButtonComponent, 
+    DxValidatorComponent,
+    DxValidationGroupComponent
+  ],
   templateUrl: './usuarios-page.component.html',
   styleUrl: './usuarios-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UsuariosPageComponent {
   private readonly securityUserService = inject(SecurityUserService);
+  protected detallesErrores: any = [];
+  protected showPasswordPopup = signal(false);
+  protected newPassword = '';
+  protected confirmNewPassword = '';
+  private selectedUser?: SecurityUserEntity;
+  protected openPasswordPopup = () => this.showPasswordPopup.set(true);
+  protected closePasswordPopup = () => this.showPasswordPopup.set(false);
+  protected togglePasswordPopup = (value: boolean) => this.showPasswordPopup.set(value);
 
-  protected readonly errorMessage = signal<string | null>(null);
-  protected readonly users = signal<SecurityUserEntity[]>([]);
-  protected readonly hasData = computed(() => this.users().length > 0);
-
-  /**
-   * DataSource de DevExpress con CRUD explícito.
-   *
-   * Métodos implementados:
-   * - load: consulta al endpoint GET /security/Usuario.
-   * - byKey: consulta GET /security/Usuario/{id}.
-   * - insert: crea usuario con POST /security/Usuario.
-   * - update: modifica usuario con PUT /security/Usuario/{id}.
-   * - remove: elimina usuario con DELETE /security/Usuario/{id}.
-   */
   protected readonly userDataSource = new CustomStore<SecurityUserEntity, string>({
     key: 'id',
-
-    load: async (): Promise<SecurityUserEntity[]> => {
+    load: async (options: LoadOptions): Promise<LoadResult<SecurityUserEntity[]>> => {
       try {
-        const data = await firstValueFrom(this.securityUserService.getAll());
-        this.users.set(data);
-        this.errorMessage.set(null);
-        return data;
-      } catch {
-        this.errorMessage.set('No se pudo cargar el listado de usuarios.');
-        throw new Error('Error loading users');
+        return await firstValueFrom(this.securityUserService.getByFilter(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
       }
     },
-
     byKey: async (key: string): Promise<SecurityUserEntity> => {
-      const row = this.users().find((item) => item.id === key);
-      if (row) {
-        return row;
-      }
-
       return firstValueFrom(this.securityUserService.getById(key));
     },
-
     insert: async (values: Partial<SecurityUserEntity>): Promise<SecurityUserEntity> => {
       const email = values.email?.trim() ?? '';
-      const password = values.passwordHash?.trim() ?? '';
+      const password = values.password?.trim() ?? '';
       const phoneNumber = values.phoneNumber?.trim() ?? '';
-
-      const created = await firstValueFrom(
-        this.securityUserService.create({
-          email,
-          password,
-          phoneNumber,
-        }),
-      );
-
-      this.users.update((current) => [...current, created]);
+      const created = {} as SecurityUserEntity;
+      try{
+        await firstValueFrom(
+          this.securityUserService.create({
+            email,
+            password,
+            phoneNumber,
+          }),
+        );
+      } catch (e: any){
+        throw NestUtils.formatValidationErrors(e);
+      }
       return created;
     },
-
     update: async (key: string, values: Partial<SecurityUserEntity>): Promise<SecurityUserEntity> => {
-      const current = this.users().find((item) => item.id === key) ?? await firstValueFrom(this.securityUserService.getById(key));
-
+      const current = await firstValueFrom(this.securityUserService.getById(key));
       const updated = await firstValueFrom(
         this.securityUserService.update({
           id: key,
           email: values.email?.trim() ?? current.email,
-          password: values.passwordHash?.trim() || current.passwordHash,
+          password: '',
           phoneNumber: values.phoneNumber?.trim() ?? current.phoneNumber ?? '',
         }),
       );
-
-      this.users.update((list) => list.map((item) => (item.id === key ? updated : item)));
       return updated;
     },
-
     remove: async (key: string): Promise<void> => {
-      await firstValueFrom(this.securityUserService.delete(key));
-      this.users.update((current) => current.filter((item) => item.id !== key));
+      await this.securityUserService.delete(key);
     },
   });
+
+  onEditorPreparing(e: DxDataGridTypes.EditorPreparingEvent<SecurityUserEntity>) {
+    if (e.dataField === 'password') {
+      e.editorOptions.visible = e.row?.isNewRow ? true : false;
+    }
+  }
+
+  onChangePasswordClick = async (e: DxDataGridTypes.CellClickEvent<SecurityUserEntity>) => {
+    const user = e.row?.data;
+    this.selectedUser = user;
+    this.newPassword = '';
+    this.confirmNewPassword = '';
+    this.openPasswordPopup();
+  }
+
+  async savePassword(validationGroup: DxValidationGroupComponent) {
+    const resultValidate = validationGroup.instance.validate();
+    if(!resultValidate.isValid){
+      return;
+    }
+    
+    await NestUtils.showConfirmationDialog({
+      title: '¿Cambiar contraseña?',
+      text: '¿Estás seguro de que deseas cambiar la contraseña de este usuario?',
+      funtionToExecute: () => this.securityUserService.resetPw({
+        id: this.selectedUser!.id,
+        password: this.newPassword
+      })
+    });
+    this.closePasswordPopup();
+    this.newPassword = '';
+    this.confirmNewPassword = '';
+  }
 }

--- a/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.ts
+++ b/nest.core.view.security/src/app/features/usuarios/pages/usuarios-page.component.ts
@@ -1,0 +1,95 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import CustomStore from 'devextreme/data/custom_store';
+import { DxDataGridModule } from 'devextreme-angular';
+
+import { SecurityUserEntity } from '@app/core/entities/security-user.entity';
+import { SecurityUserService } from '@app/core/services/security-user.service';
+
+@Component({
+  selector: 'app-usuarios-page',
+  imports: [DxDataGridModule],
+  templateUrl: './usuarios-page.component.html',
+  styleUrl: './usuarios-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UsuariosPageComponent {
+  private readonly securityUserService = inject(SecurityUserService);
+
+  protected readonly errorMessage = signal<string | null>(null);
+  protected readonly users = signal<SecurityUserEntity[]>([]);
+  protected readonly hasData = computed(() => this.users().length > 0);
+
+  /**
+   * DataSource de DevExpress con CRUD explícito.
+   *
+   * Métodos implementados:
+   * - load: consulta al endpoint GET /security/Usuario.
+   * - byKey: consulta GET /security/Usuario/{id}.
+   * - insert: crea usuario con POST /security/Usuario.
+   * - update: modifica usuario con PUT /security/Usuario/{id}.
+   * - remove: elimina usuario con DELETE /security/Usuario/{id}.
+   */
+  protected readonly userDataSource = new CustomStore<SecurityUserEntity, string>({
+    key: 'id',
+
+    load: async (): Promise<SecurityUserEntity[]> => {
+      try {
+        const data = await firstValueFrom(this.securityUserService.getAll());
+        this.users.set(data);
+        this.errorMessage.set(null);
+        return data;
+      } catch {
+        this.errorMessage.set('No se pudo cargar el listado de usuarios.');
+        throw new Error('Error loading users');
+      }
+    },
+
+    byKey: async (key: string): Promise<SecurityUserEntity> => {
+      const row = this.users().find((item) => item.id === key);
+      if (row) {
+        return row;
+      }
+
+      return firstValueFrom(this.securityUserService.getById(key));
+    },
+
+    insert: async (values: Partial<SecurityUserEntity>): Promise<SecurityUserEntity> => {
+      const email = values.email?.trim() ?? '';
+      const password = values.passwordHash?.trim() ?? '';
+      const phoneNumber = values.phoneNumber?.trim() ?? '';
+
+      const created = await firstValueFrom(
+        this.securityUserService.create({
+          email,
+          password,
+          phoneNumber,
+        }),
+      );
+
+      this.users.update((current) => [...current, created]);
+      return created;
+    },
+
+    update: async (key: string, values: Partial<SecurityUserEntity>): Promise<SecurityUserEntity> => {
+      const current = this.users().find((item) => item.id === key) ?? await firstValueFrom(this.securityUserService.getById(key));
+
+      const updated = await firstValueFrom(
+        this.securityUserService.update({
+          id: key,
+          email: values.email?.trim() ?? current.email,
+          password: values.passwordHash?.trim() || current.passwordHash,
+          phoneNumber: values.phoneNumber?.trim() ?? current.phoneNumber ?? '',
+        }),
+      );
+
+      this.users.update((list) => list.map((item) => (item.id === key ? updated : item)));
+      return updated;
+    },
+
+    remove: async (key: string): Promise<void> => {
+      await firstValueFrom(this.securityUserService.delete(key));
+      this.users.update((current) => current.filter((item) => item.id !== key));
+    },
+  });
+}

--- a/nest.core.view.security/src/main.ts
+++ b/nest.core.view.security/src/main.ts
@@ -2,7 +2,12 @@ import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
+import { locale, loadMessages } from 'devextreme/localization';
+import esMessages from 'devextreme/localization/messages/es.json';
 
+
+loadMessages(esMessages);
+locale('es');
 bootstrapApplication(AppComponent, appConfig).catch((error: unknown) => {
   console.error('Application bootstrap failed', error);
 });

--- a/nest.core.view.security/src/styles.scss
+++ b/nest.core.view.security/src/styles.scss
@@ -32,3 +32,11 @@ body {
 .multi-level-menu .dropdown-toggle::after {
   margin-left: 0.45rem;
 }
+
+.dx-error-message {
+    white-space: pre-line !important;
+}
+
+.swal-on-top {
+  z-index: 20000 !important;
+}


### PR DESCRIPTION
### Motivation
- Proveer un mantenimiento de "Usuarios" en el frontend `nest.core.view.security` consumiendo el API existente en `nest.core.security` y respetando el patrón del proyecto. 
- Usar DevExpress DataGrid con un `CustomStore` para exponer operaciones CRUD explícitas y facilitar integración con la UI de administración.

### Description
- Se añadió la interfaz `SecurityUserEntity` y payloads `SecurityUserCreatePayload` / `SecurityUserUpdatePayload` para mapear la entidad completa devuelta por el endpoint `Usuario`. 
- Se implementó `SecurityUserService` con métodos `getAll()`, `getById(id)`, `create(payload)`, `update(payload)` y `delete(id)` apuntando a `{{apiBaseUrl}}/security/Usuario`. 
- Se creó `UsuariosPageComponent` (template, SCSS y TS) que contiene un `dx-data-grid` y un `CustomStore` con los métodos `load`, `byKey`, `insert`, `update` y `remove` implementados y sincronizando un cache local en `signal`. 
- Se registró la ruta protegida `/usuarios` en `app.routes.ts`, se enlazó el menú a `/usuarios` y se agregaron las dependencias y estilo de DevExpress en `package.json` y `angular.json` para soportar el grid. 

### Testing
- Se intentó instalar las dependencias con `npm install devextreme devextreme-angular` en `nest.core.view.security` y la operación falló por restricciones del entorno (`403 Forbidden` contra el registro npm). 
- Se ejecutó `npm run build` en `nest.core.view.security` y la compilación falló por la falta de `devextreme` / `devextreme-angular` (import/resolution/type errors) derivado de la imposibilidad de instalar los paquetes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96d31c5f08333a3685f42cbd616b6)