### PR TITLE
Add role filtering API and Roles maintenance UI

### DIFF
--- a/nest.core.aplicacion.security/Roles/Handlers/ObtenerRolesFilterHandler.cs
+++ b/nest.core.aplicacion.security/Roles/Handlers/ObtenerRolesFilterHandler.cs
@@ -1,0 +1,34 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.security.Roles.Queries;
+using nest.core.dominio.Security;
+
+namespace nest.core.aplicacion.security.Roles.Handlers;
+
+public class ObtenerRolesFilterHandler : IRequestHandler<ObtenerRolesFilterQuery, LoadResult>
+{
+    private readonly RoleManager<ApplicationRole> roleManager;
+    private readonly ILogger<ObtenerRolesFilterHandler> logger;
+
+    public ObtenerRolesFilterHandler(RoleManager<ApplicationRole> roleManager, ILogger<ObtenerRolesFilterHandler> logger)
+    {
+        this.roleManager = roleManager;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerRolesFilterQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await DataSourceLoader.LoadAsync(roleManager.Roles, request.LoadOptions, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los roles con filtro");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.security/Roles/Queries/ObtenerRolesFilterQuery.cs
+++ b/nest.core.aplicacion.security/Roles/Queries/ObtenerRolesFilterQuery.cs
@@ -1,0 +1,9 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.security.Roles.Queries;
+
+public record ObtenerRolesFilterQuery(
+    DataSourceLoadOptionsBase LoadOptions
+) : IRequest<LoadResult>;

--- a/nest.core.security/Controllers/RolController.cs
+++ b/nest.core.security/Controllers/RolController.cs
@@ -1,3 +1,5 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using System.Collections.Generic;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -28,6 +30,16 @@ public class RolController : Controller
     public async Task<ActionResult<List<ApplicationRole>>> ObtenerTodos(CancellationToken ct)
     {
         var data = await sender.Send(new ObtenerRolesQuery(), ct);
+        return Ok(data);
+    }
+
+    [HttpPost("filter")]
+    [ProducesResponseType(typeof(LoadResult), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    [ProducesResponseType(401)]
+    public async Task<ActionResult<LoadResult>> ObtenerFiltro([FromBody] DataSourceLoadOptionsBase loadOptions, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerRolesFilterQuery(loadOptions), ct);
         return Ok(data);
     }
 

--- a/nest.core.view.security/src/app/app.routes.ts
+++ b/nest.core.view.security/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { authGuard } from './core/auth/auth.guard';
 import { ShellComponent } from './layout/shell/shell.component';
 import { LoginPageComponent } from './features/auth/pages/login-page.component';
 import { MainPageComponent } from './features/main/pages/main-page.component';
+import { RolesPageComponent } from './features/roles/pages/roles-page.component';
 import { UsuariosPageComponent } from './features/usuarios/pages/usuarios-page.component';
 
 export const appRoutes: Routes = [
@@ -25,6 +26,11 @@ export const appRoutes: Routes = [
         path: 'usuarios',
         component: UsuariosPageComponent,
         title: 'Usuarios',
+      },
+      {
+        path: 'roles',
+        component: RolesPageComponent,
+        title: 'Roles',
       },
     ],
   },

--- a/nest.core.view.security/src/app/core/entities/security-role.entity.ts
+++ b/nest.core.view.security/src/app/core/entities/security-role.entity.ts
@@ -1,0 +1,17 @@
+export interface SecurityRoleEntity {
+  id: string;
+  name: string;
+  normalizedName: string;
+  concurrencyStamp: string;
+  empresaId: number;
+}
+
+export interface SecurityRoleCreatePayload {
+  empresaId: number;
+  name: string;
+}
+
+export interface SecurityRoleUpdatePayload {
+  id: number;
+  name: string;
+}

--- a/nest.core.view.security/src/app/core/services/roles/security-role.service.ts
+++ b/nest.core.view.security/src/app/core/services/roles/security-role.service.ts
@@ -1,0 +1,43 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+
+import {
+  SecurityRoleCreatePayload,
+  SecurityRoleEntity,
+  SecurityRoleUpdatePayload,
+} from '@app/core/entities/security-role.entity';
+import { environment } from '@environment/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SecurityRoleService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly endpoint = `${environment.apiBaseUrl}/security/Rol`;
+
+  getAll(): Observable<SecurityRoleEntity[]> {
+    return this.httpClient.get<SecurityRoleEntity[]>(this.endpoint);
+  }
+
+  getByFilter(loadOptions: LoadOptions): Observable<LoadResult<SecurityRoleEntity[]>> {
+    return this.httpClient.post<LoadResult<SecurityRoleEntity[]>>(`${this.endpoint}/filter`, loadOptions);
+  }
+
+  getById(id: string): Observable<SecurityRoleEntity> {
+    return this.httpClient.get<SecurityRoleEntity>(`${this.endpoint}/${id}`);
+  }
+
+  create(payload: SecurityRoleCreatePayload): Observable<SecurityRoleEntity> {
+    return this.httpClient.post<SecurityRoleEntity>(this.endpoint, payload);
+  }
+
+  update(payload: SecurityRoleUpdatePayload): Observable<SecurityRoleEntity> {
+    return this.httpClient.put<SecurityRoleEntity>(`${this.endpoint}/${payload.id}`, payload);
+  }
+
+  delete(id: number): Observable<boolean> {
+    return this.httpClient.delete<boolean>(`${this.endpoint}/${id}`);
+  }
+}

--- a/nest.core.view.security/src/app/core/services/ui/menu.service.ts
+++ b/nest.core.view.security/src/app/core/services/ui/menu.service.ts
@@ -16,7 +16,7 @@ export class MenuService {
           },
           {
             label: 'Roles',
-            route: '/',
+            route: '/roles',
           },
         ],
       },

--- a/nest.core.view.security/src/app/core/services/ui/user-session.service.ts
+++ b/nest.core.view.security/src/app/core/services/ui/user-session.service.ts
@@ -7,4 +7,5 @@ import { AuthService } from '../security/auth.service';
 export class UserSessionService {
   private readonly authService = inject(AuthService);
   currentUser = this.authService.currentUser;
+  empresaId = this.authService.currentUser()!.empresaId;
 }

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
@@ -29,13 +29,13 @@
         <dxo-popup title="Rol" [showTitle]="true"></dxo-popup>
         <dxo-form [colCount]="2">
           <dxi-item dataField="name" [isRequired]="true"></dxi-item>
-          <dxi-item dataField="empresaId" [isRequired]="true" editorType="dxNumberBox"></dxi-item>
+          <dxi-item dataField="empresaId" [isRequired]="true"></dxi-item>
         </dxo-form>
       </dxo-editing>
 
       <dxi-column dataField="id" caption="Id" [allowEditing]="false" [visible]="false"></dxi-column>
       <dxi-column dataField="name" caption="Nombre" [validationRules]="[{ type: 'required' }]"></dxi-column>
-      <dxi-column dataField="empresaId" caption="Empresa" dataType="number" [allowEditing]="true"></dxi-column>
+      <dxi-column dataField="empresaId" caption="Empresa" dataType="number" [visible]="true" [allowEditing]="true"></dxi-column>
       <dxi-column dataField="normalizedName" caption="Nombre Normalizado" [allowEditing]="false"></dxi-column>
       <dxi-column type="buttons">
         <dxi-button name="edit"></dxi-button>

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
@@ -1,0 +1,46 @@
+<section class="card shadow-sm border-0">
+  <header class="card-header border-bottom">
+    <h5 class="mb-0">Mantenimiento de Roles</h5>
+  </header>
+
+  <div class="card-body">
+    <dx-data-grid
+      class="roles-grid"
+      [dataSource]="rolesDataSource"
+      [showBorders]="true"
+      [rowAlternationEnabled]="true"
+      [remoteOperations]="true"
+      [columnAutoWidth]="true"
+      [selection]="{ mode: 'single' }"
+      [showRowLines]="true"
+    >
+      <dxo-search-panel [visible]="true" [highlightCaseSensitive]="false"></dxo-search-panel>
+      <dxo-filter-row [visible]="true"></dxo-filter-row>
+      <dxo-data-grid-header-filter [visible]="true"></dxo-data-grid-header-filter>
+      <dxo-paging [pageSize]="10"></dxo-paging>
+      <dxo-pager [showPageSizeSelector]="true" [allowedPageSizes]="[10, 20, 50]" [showInfo]="true"></dxo-pager>
+      <dxo-editing
+        mode="popup"
+        [allowAdding]="true"
+        [allowUpdating]="true"
+        [allowDeleting]="true"
+        [useIcons]="true"
+      >
+        <dxo-popup title="Rol" [showTitle]="true"></dxo-popup>
+        <dxo-form [colCount]="2">
+          <dxi-item dataField="name" [isRequired]="true"></dxi-item>
+          <dxi-item dataField="empresaId" [isRequired]="true" editorType="dxNumberBox"></dxi-item>
+        </dxo-form>
+      </dxo-editing>
+
+      <dxi-column dataField="id" caption="Id" [allowEditing]="false" [visible]="false"></dxi-column>
+      <dxi-column dataField="name" caption="Nombre" [validationRules]="[{ type: 'required' }]"></dxi-column>
+      <dxi-column dataField="empresaId" caption="Empresa" dataType="number" [allowEditing]="true"></dxi-column>
+      <dxi-column dataField="normalizedName" caption="Nombre Normalizado" [allowEditing]="false"></dxi-column>
+      <dxi-column type="buttons">
+        <dxi-button name="edit"></dxi-button>
+        <dxi-button name="delete"></dxi-button>
+      </dxi-column>
+    </dx-data-grid>
+  </div>
+</section>

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.scss
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import CustomStore from 'devextreme/data/custom_store';
+import { DxDataGridModule } from 'devextreme-angular';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+
+import { SecurityRoleEntity } from '@app/core/entities/security-role.entity';
+import { SecurityRoleService } from '@app/core/services/roles/security-role.service';
+import { NestUtils } from '@app/core/services/util/nestUtils';
+
+@Component({
+  selector: 'app-roles-page',
+  imports: [DxDataGridModule],
+  templateUrl: './roles-page.component.html',
+  styleUrl: './roles-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RolesPageComponent {
+  private readonly securityRoleService = inject(SecurityRoleService);
+
+  protected readonly rolesDataSource = new CustomStore<SecurityRoleEntity, string>({
+    key: 'id',
+    load: async (options: LoadOptions): Promise<LoadResult<SecurityRoleEntity[]>> => {
+      try {
+        return await firstValueFrom(this.securityRoleService.getByFilter(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
+    },
+    byKey: async (key: string): Promise<SecurityRoleEntity> => {
+      return firstValueFrom(this.securityRoleService.getById(key));
+    },
+    insert: async (values: Partial<SecurityRoleEntity>): Promise<SecurityRoleEntity> => {
+      const name = values.name?.trim() ?? '';
+      const empresaId = Number(values.empresaId ?? 0);
+
+      try {
+        return await firstValueFrom(this.securityRoleService.create({ empresaId, name }));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
+    },
+    update: async (key: string, values: Partial<SecurityRoleEntity>): Promise<SecurityRoleEntity> => {
+      const current = await firstValueFrom(this.securityRoleService.getById(key));
+      return await firstValueFrom(
+        this.securityRoleService.update({
+          id: Number(key),
+          name: values.name?.trim() ?? current.name,
+        }),
+      );
+    },
+    remove: async (key: string): Promise<void> => {
+      await firstValueFrom(this.securityRoleService.delete(Number(key)));
+    },
+  });
+}

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
@@ -4,19 +4,23 @@ import CustomStore from 'devextreme/data/custom_store';
 import { DxDataGridModule } from 'devextreme-angular';
 import { LoadOptions, LoadResult } from 'devextreme/common/data';
 
-import { SecurityRoleEntity } from '@app/core/entities/security-role.entity';
+import { SecurityRoleCreatePayload, SecurityRoleEntity } from '@app/core/entities/security-role.entity';
 import { SecurityRoleService } from '@app/core/services/roles/security-role.service';
+import { UserSessionService } from '@app/core/services/ui/user-session.service';
 import { NestUtils } from '@app/core/services/util/nestUtils';
+import { ɵInternalFormsSharedModule } from "@angular/forms";
 
 @Component({
   selector: 'app-roles-page',
-  imports: [DxDataGridModule],
+  imports: [DxDataGridModule, ɵInternalFormsSharedModule],
   templateUrl: './roles-page.component.html',
   styleUrl: './roles-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RolesPageComponent {
   private readonly securityRoleService = inject(SecurityRoleService);
+  private readonly userService = inject(UserSessionService);
+  protected readonly empresaId = this.userService.empresaId;
 
   protected readonly rolesDataSource = new CustomStore<SecurityRoleEntity, string>({
     key: 'id',
@@ -31,11 +35,9 @@ export class RolesPageComponent {
       return firstValueFrom(this.securityRoleService.getById(key));
     },
     insert: async (values: Partial<SecurityRoleEntity>): Promise<SecurityRoleEntity> => {
-      const name = values.name?.trim() ?? '';
-      const empresaId = Number(values.empresaId ?? 0);
-
+      values.empresaId = this.empresaId;
       try {
-        return await firstValueFrom(this.securityRoleService.create({ empresaId, name }));
+        return await firstValueFrom(this.securityRoleService.create(values as SecurityRoleCreatePayload));
       } catch (e: any) {
         throw NestUtils.formatValidationErrors(e);
       }


### PR DESCRIPTION
### Motivation
- Proveer la misma funcionalidad de filtrado que tiene `UsuarioController` para la entidad Role y habilitar mantenimiento CRUD de roles desde la UI de `nest.core.view.security`.
- Reutilizar el patrón de DevExtreme `DataSourceLoadOptionsBase` / `DataSourceLoader.LoadAsync` para permitir búsquedas/paginación remota coherente con otros controladores.

### Description
- Añadido endpoint `POST /Rol/filter` en `RolController` que recibe `DataSourceLoadOptionsBase` y delega a la capa de aplicación con `ObtenerRolesFilterQuery`.
- Implementados `ObtenerRolesFilterQuery` y `ObtenerRolesFilterHandler` en `nest.core.aplicacion.security` que usan `DataSourceLoader.LoadAsync(roleManager.Roles, ...)` para aplicar filtros/paginación.
- Agregado soporte en la UI (`nest.core.view.security`) con los contratos de datos `SecurityRoleEntity`, el servicio `SecurityRoleService` (con `getByFilter`) y una nueva página `RolesPageComponent` (TS/HTML/SCSS) que usa `DevExtreme` `DataGrid` para CRUD remoto.
- Registrada la ruta `/roles` en `app.routes.ts` y actualizado el menú para enlazar a la nueva pantalla; además se añadieron las declaraciones `using` necesarias en el controlador.

### Testing
- Intenté `dotnet build nest.core.aplicacion.security` pero falló en este entorno porque `dotnet` no está instalado (no se pudo ejecutar la compilación del backend aquí).
- Intenté `dotnet build nest.core.security` y también falló por la misma razón (entorno sin `dotnet`).
- Ejecuté `npm run build` para `nest.core.view.security`; la compilación arrancó pero la generación del bundle falló por límites/budgets del proyecto Angular preexistentes (advertencias de CommonJS y presupuesto de bundle), lo cual no está causado por estos cambios de funcionalidad.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0281715288333ba8118c620886655)