### PR TITLE
feat(roles-page): empresaId como lookup usando endpoint corporativo `filter_activos`

### DIFF
--- a/nest.core.aplicacion.security/Roles/Handlers/ObtenerRolesFilterHandler.cs
+++ b/nest.core.aplicacion.security/Roles/Handlers/ObtenerRolesFilterHandler.cs
@@ -1,10 +1,10 @@
-using DevExtreme.AspNet.Data;
 using DevExtreme.AspNet.Data.ResponseModel;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using nest.core.aplicacion.security.Roles.Queries;
 using nest.core.dominio.Security;
+using nest.core.infrastructura.utils.DataLoader;
 
 namespace nest.core.aplicacion.security.Roles.Handlers;
 
@@ -23,7 +23,7 @@ public class ObtenerRolesFilterHandler : IRequestHandler<ObtenerRolesFilterQuery
     {
         try
         {
-            return await DataSourceLoader.LoadAsync(roleManager.Roles, request.LoadOptions, cancellationToken);
+            return await DataSourceLoaderLw.LoadAsync(roleManager.Roles, request.LoadOptions, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/nest.core.aplicacion.security/Roles/Handlers/RoleCrearHandler.cs
+++ b/nest.core.aplicacion.security/Roles/Handlers/RoleCrearHandler.cs
@@ -29,7 +29,7 @@ public class RoleCrearHandler : IRequestHandler<RoleCrearCommand, ApplicationRol
         {
             string lastValue = await context.Roles
                 .IgnoreQueryFilters()
-                .OrderByDescending(r => r.Id)
+                .OrderByDescending(r => Convert.ToInt64(r.Id))
                 .Select(r => r.Id)
                 .FirstOrDefaultAsync(cancellationToken) ?? "0";
 

--- a/nest.core.aplicacion.security/Usuarios/Handlers/ObtenerFilterHandler.cs
+++ b/nest.core.aplicacion.security/Usuarios/Handlers/ObtenerFilterHandler.cs
@@ -1,16 +1,10 @@
-using DevExtreme.AspNet.Data;
 using DevExtreme.AspNet.Data.ResponseModel;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using nest.core.aplicacion.security.Usuarios.Queries;
 using nest.core.dominio.Security;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
+using nest.core.infrastructura.utils.DataLoader;
 
 namespace nest.core.aplicacion.security.Usuarios.Handlers
 {
@@ -29,7 +23,7 @@ namespace nest.core.aplicacion.security.Usuarios.Handlers
         {
             try
             {
-                return await DataSourceLoader.LoadAsync(userManager.Users, request.loadOptions);
+                return await DataSourceLoaderLw.LoadAsync(userManager.Users, request.loadOptions);
             }
             catch (Exception ex)
             {

--- a/nest.core.corporativo/Controllers/EmpresaController.cs
+++ b/nest.core.corporativo/Controllers/EmpresaController.cs
@@ -64,7 +64,7 @@ namespace nest.core.corporativo.Controllers
         /// <summary>
         /// Obtiene todas las empresas aplicando filtros y paginación según las opciones de carga proporcionadas.
         /// </summary>
-        [HttpGet("filter")]
+        [HttpPost("filter")]
         [ProducesResponseType(typeof(List<Empresa>), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
         public async Task<ActionResult<LoadResult>> ObtenerFiltro([FromBody] DataSourceLoadOptionsBase loadOptions, CancellationToken ct)
@@ -76,7 +76,7 @@ namespace nest.core.corporativo.Controllers
         /// <summary>
         /// Obtiene todas las empresas activas aplicando filtros y paginación según las opciones de carga proporcionadas.
         /// </summary>
-        [HttpGet("filter_activos")]
+        [HttpPost("filter_activos")]
         [ProducesResponseType(typeof(List<Empresa>), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
         public async Task<ActionResult<LoadResult>> ObtenerFiltroActivos([FromBody] DataSourceLoadOptionsBase loadOptions, CancellationToken ct)

--- a/nest.core.infraestructura.corporativo/EmpresaRepository.cs
+++ b/nest.core.infraestructura.corporativo/EmpresaRepository.cs
@@ -6,6 +6,7 @@ using nest.core.dominio.Cache;
 using nest.core.dominio.Corporativo.Empresa;
 using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
+using nest.core.infrastructura.utils.DataLoader;
 
 namespace nest.core.infraestructura.corporativo
 {
@@ -22,8 +23,8 @@ namespace nest.core.infraestructura.corporativo
                 .OrderBy(x => x.Nombre);
         }
         public async Task<Empresa?> ObtenerPorId(int id) => await GetByIdAsync(id);
-        public async Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoader.LoadAsync(Query(), options, cancellationToken);
-        public async Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoader.LoadAsync(Query().Where(x => x.Estado), options, cancellationToken);
+        public async Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoaderLw.LoadAsync(Query(), options, cancellationToken);
+        public async Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoaderLw.LoadAsync(Query().Where(x => x.Estado), options, cancellationToken);
         public async Task<List<Empresa>> ObtenerTodos() => await GetAllAsync();
         public async Task<List<Empresa>> ObtenerActivos() => (await GetCachedListAsync()).Where(x => x.Estado).ToList();
         public async Task<Empresa> Agregar(Empresa entidad) => await AddAsync(entidad);

--- a/nest.core.infrastructura.utils/DataLoader/DataSourceLoaderLw.cs
+++ b/nest.core.infrastructura.utils/DataLoader/DataSourceLoaderLw.cs
@@ -1,0 +1,27 @@
+﻿using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+
+namespace nest.core.infrastructura.utils.DataLoader
+{
+    public static class DataSourceLoaderLw
+    {
+        public static LoadResult Load<T>(
+            IQueryable<T> query,
+            DataSourceLoadOptionsBase loadOptions)
+        {
+            loadOptions.StringToLower = true;
+
+            return DataSourceLoader.Load(query, loadOptions);
+        }
+
+        public static async Task<LoadResult> LoadAsync<T>(
+            IQueryable<T> query,
+            DataSourceLoadOptionsBase loadOptions,
+            CancellationToken ct = default)
+        {
+            loadOptions.StringToLower = true;
+
+            return await DataSourceLoader.LoadAsync(query, loadOptions, ct);
+        }
+    }
+}

--- a/nest.core.view.security/src/app/core/entities/empresa.entity.ts
+++ b/nest.core.view.security/src/app/core/entities/empresa.entity.ts
@@ -1,0 +1,6 @@
+export interface EmpresaEntity {
+  id: number;
+  nombre: string;
+  nombreCorto: string;
+  activo: boolean;
+}

--- a/nest.core.view.security/src/app/core/services/empresas/empresa.service.ts
+++ b/nest.core.view.security/src/app/core/services/empresas/empresa.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+
+import { EmpresaEntity } from '@app/core/entities/empresa.entity';
+import { environment } from '@environment/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EmpresaService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly endpoint = `${environment.apiBaseUrl}/corporativo/Empresa`;
+
+  getById(id: number): Observable<EmpresaEntity> {
+    return this.httpClient.get<EmpresaEntity>(`${this.endpoint}/${id}`);
+  }
+
+  getActivosByFilter(loadOptions: LoadOptions): Observable<LoadResult<EmpresaEntity[]> | EmpresaEntity[]> {
+    return this.httpClient.request<LoadResult<EmpresaEntity[]> | EmpresaEntity[]>('GET', `${this.endpoint}/filter_activos`, {
+      body: loadOptions,
+    });
+  }
+}

--- a/nest.core.view.security/src/app/core/services/empresas/empresa.service.ts
+++ b/nest.core.view.security/src/app/core/services/empresas/empresa.service.ts
@@ -17,9 +17,7 @@ export class EmpresaService {
     return this.httpClient.get<EmpresaEntity>(`${this.endpoint}/${id}`);
   }
 
-  getActivosByFilter(loadOptions: LoadOptions): Observable<LoadResult<EmpresaEntity[]> | EmpresaEntity[]> {
-    return this.httpClient.request<LoadResult<EmpresaEntity[]> | EmpresaEntity[]>('GET', `${this.endpoint}/filter_activos`, {
-      body: loadOptions,
-    });
+  getActivosByFilter(loadOptions: LoadOptions): Observable<LoadResult<EmpresaEntity[]>> {
+    return this.httpClient.post<LoadResult<EmpresaEntity[]>>(`${this.endpoint}/filter_activos`, loadOptions);
   }
 }

--- a/nest.core.view.security/src/app/core/services/util/nestUtils.ts
+++ b/nest.core.view.security/src/app/core/services/util/nestUtils.ts
@@ -1,3 +1,4 @@
+import { LoadOptions } from "devextreme/data";
 import { firstValueFrom } from "rxjs";
 import Swal from "sweetalert2";
 
@@ -30,6 +31,12 @@ export class NestUtils {
             return `${error.message}`;
         }
         return 'Ha ocurrido un error desconocido.';
+    }
+
+    public static normalizeLookUpSearch(options: LoadOptions){
+        if(!options.filter && options.searchExpr && options.searchValue)
+            options.filter = [[options.searchExpr, options.searchOperation, options.searchValue]];
+        return options;
     }
 
     public static async showConfirmationDialog(options: any) {

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
@@ -20,28 +20,12 @@
       <dxo-paging [pageSize]="10"></dxo-paging>
       <dxo-pager [showPageSizeSelector]="true" [allowedPageSizes]="[10, 20, 50]" [showInfo]="true"></dxo-pager>
       <dxo-editing
-        mode="popup"
+        mode="form"
         [allowAdding]="true"
         [allowUpdating]="true"
         [allowDeleting]="true"
         [useIcons]="true"
       >
-        <dxo-popup title="Rol" [showTitle]="true"></dxo-popup>
-        <dxo-form [colCount]="2">
-          <dxi-item dataField="name" [isRequired]="true"></dxi-item>
-          <dxi-item
-            dataField="empresaId"
-            [isRequired]="true"
-            editorType="dxSelectBox"
-            [editorOptions]="{
-              dataSource: empresasDataSource,
-              valueExpr: 'id',
-              displayExpr: 'nombreCorto',
-              searchEnabled: true,
-              showClearButton: false
-            }"
-          ></dxi-item>
-        </dxo-form>
       </dxo-editing>
 
       <dxi-column dataField="id" caption="Id" [allowEditing]="false" [visible]="false"></dxi-column>
@@ -49,11 +33,12 @@
       <dxi-column
         dataField="empresaId"
         caption="Empresa"
-        dataType="number"
-        [visible]="true"
-        [allowEditing]="true"
-      >
-        <dxo-lookup [dataSource]="empresasDataSource" valueExpr="id" displayExpr="nombreCorto"></dxo-lookup>
+        dataType="number">
+        <dxo-lookup
+          [dataSource]="this.empresasDsWrapper" 
+          valueExpr="id"
+          displayExpr="nombre">
+        </dxo-lookup>
       </dxi-column>
       <dxi-column dataField="normalizedName" caption="Nombre Normalizado" [allowEditing]="false"></dxi-column>
       <dxi-column type="buttons">

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.html
@@ -29,13 +29,32 @@
         <dxo-popup title="Rol" [showTitle]="true"></dxo-popup>
         <dxo-form [colCount]="2">
           <dxi-item dataField="name" [isRequired]="true"></dxi-item>
-          <dxi-item dataField="empresaId" [isRequired]="true"></dxi-item>
+          <dxi-item
+            dataField="empresaId"
+            [isRequired]="true"
+            editorType="dxSelectBox"
+            [editorOptions]="{
+              dataSource: empresasDataSource,
+              valueExpr: 'id',
+              displayExpr: 'nombreCorto',
+              searchEnabled: true,
+              showClearButton: false
+            }"
+          ></dxi-item>
         </dxo-form>
       </dxo-editing>
 
       <dxi-column dataField="id" caption="Id" [allowEditing]="false" [visible]="false"></dxi-column>
-      <dxi-column dataField="name" caption="Nombre" [validationRules]="[{ type: 'required' }]"></dxi-column>
-      <dxi-column dataField="empresaId" caption="Empresa" dataType="number" [visible]="true" [allowEditing]="true"></dxi-column>
+      <dxi-column dataField="name" caption="Nombre" [validationRules]="[{ type: 'required' }]" ></dxi-column>
+      <dxi-column
+        dataField="empresaId"
+        caption="Empresa"
+        dataType="number"
+        [visible]="true"
+        [allowEditing]="true"
+      >
+        <dxo-lookup [dataSource]="empresasDataSource" valueExpr="id" displayExpr="nombreCorto"></dxo-lookup>
+      </dxi-column>
       <dxi-column dataField="normalizedName" caption="Nombre Normalizado" [allowEditing]="false"></dxi-column>
       <dxi-column type="buttons">
         <dxi-button name="edit"></dxi-button>

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import CustomStore from 'devextreme/data/custom_store';
 import { DxDataGridModule } from 'devextreme-angular';
-import { LoadOptions, LoadResult } from 'devextreme/common/data';
+import { CustomStoreOptions, DataSource, DataSourceOptions, LoadOptions, LoadResult } from 'devextreme/common/data';
 
 import { SecurityRoleCreatePayload, SecurityRoleEntity } from '@app/core/entities/security-role.entity';
 import { SecurityRoleService } from '@app/core/services/roles/security-role.service';
@@ -11,6 +11,7 @@ import { NestUtils } from '@app/core/services/util/nestUtils';
 import { ɵInternalFormsSharedModule } from '@angular/forms';
 import { EmpresaEntity } from '@app/core/entities/empresa.entity';
 import { EmpresaService } from '@app/core/services/empresas/empresa.service';
+import { DxSelectBoxTypes } from 'devextreme-angular/ui/select-box';
 
 @Component({
   selector: 'app-roles-page',
@@ -24,22 +25,31 @@ export class RolesPageComponent {
   private readonly empresaService = inject(EmpresaService);
   private readonly userService = inject(UserSessionService);
   protected readonly empresaId = this.userService.empresaId;
-
+  
   protected readonly empresasDataSource = new CustomStore<EmpresaEntity, number>({
     key: 'id',
-    loadMode: 'raw',
-    load: async (options: LoadOptions): Promise<EmpresaEntity[]> => {
-      const result = await firstValueFrom(this.empresaService.getActivosByFilter(options));
-      const rawData = Array.isArray(result) ? result : (result as { data?: EmpresaEntity[] }).data;
-      return rawData ?? [];
+    useDefaultSearch: true,
+    load: async (options: LoadOptions): Promise<LoadResult<EmpresaEntity[]>> => {
+      try {
+        return await firstValueFrom(this.empresaService.getActivosByFilter(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
     },
     byKey: async (key: number): Promise<EmpresaEntity> => {
       return await firstValueFrom(this.empresaService.getById(Number(key)));
     },
   });
 
+  protected readonly empresasDsWrapper: DataSourceOptions<EmpresaEntity, number> = {
+    store: this.empresasDataSource,
+    paginate: true,
+    pageSize: 10,
+  };
+
   protected readonly rolesDataSource = new CustomStore<SecurityRoleEntity, string>({
     key: 'id',
+    useDefaultSearch: true,
     load: async (options: LoadOptions): Promise<LoadResult<SecurityRoleEntity[]>> => {
       try {
         return await firstValueFrom(this.securityRoleService.getByFilter(options));

--- a/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
+++ b/nest.core.view.security/src/app/features/roles/pages/roles-page.component.ts
@@ -8,7 +8,9 @@ import { SecurityRoleCreatePayload, SecurityRoleEntity } from '@app/core/entitie
 import { SecurityRoleService } from '@app/core/services/roles/security-role.service';
 import { UserSessionService } from '@app/core/services/ui/user-session.service';
 import { NestUtils } from '@app/core/services/util/nestUtils';
-import { ɵInternalFormsSharedModule } from "@angular/forms";
+import { ɵInternalFormsSharedModule } from '@angular/forms';
+import { EmpresaEntity } from '@app/core/entities/empresa.entity';
+import { EmpresaService } from '@app/core/services/empresas/empresa.service';
 
 @Component({
   selector: 'app-roles-page',
@@ -19,8 +21,22 @@ import { ɵInternalFormsSharedModule } from "@angular/forms";
 })
 export class RolesPageComponent {
   private readonly securityRoleService = inject(SecurityRoleService);
+  private readonly empresaService = inject(EmpresaService);
   private readonly userService = inject(UserSessionService);
   protected readonly empresaId = this.userService.empresaId;
+
+  protected readonly empresasDataSource = new CustomStore<EmpresaEntity, number>({
+    key: 'id',
+    loadMode: 'raw',
+    load: async (options: LoadOptions): Promise<EmpresaEntity[]> => {
+      const result = await firstValueFrom(this.empresaService.getActivosByFilter(options));
+      const rawData = Array.isArray(result) ? result : (result as { data?: EmpresaEntity[] }).data;
+      return rawData ?? [];
+    },
+    byKey: async (key: number): Promise<EmpresaEntity> => {
+      return await firstValueFrom(this.empresaService.getById(Number(key)));
+    },
+  });
 
   protected readonly rolesDataSource = new CustomStore<SecurityRoleEntity, string>({
     key: 'id',
@@ -35,7 +51,7 @@ export class RolesPageComponent {
       return firstValueFrom(this.securityRoleService.getById(key));
     },
     insert: async (values: Partial<SecurityRoleEntity>): Promise<SecurityRoleEntity> => {
-      values.empresaId = this.empresaId;
+      values.empresaId = values.empresaId ? Number(values.empresaId) : this.empresaId;
       try {
         return await firstValueFrom(this.securityRoleService.create(values as SecurityRoleCreatePayload));
       } catch (e: any) {


### PR DESCRIPTION
### Motivation
- Hacer que `empresaId` sea un campo lookup (lista desplegable) en la gestión de roles para seleccionar visualmente la empresa y aprovechar el endpoint de empresas activas.

### Description
- Se agregó la interfaz `EmpresaEntity` en `src/app/core/entities/empresa.entity.ts` para tipar los datos de empresa.
- Se creó `EmpresaService` en `src/app/core/services/empresas/empresa.service.ts` que consume `GET /corporativo/Empresa/filter_activos` y `GET /corporativo/Empresa/{id}`.
- Se actualizó `roles-page.component.ts` para inyectar `EmpresaService`, crear `empresasDataSource` como `CustomStore` y aplicar fallback al `empresaId` de sesión al insertar; y se actualizó `roles-page.component.html` para usar `dxSelectBox` en el popup y `dxo-lookup` en la columna `empresaId` del grid.

### Testing
- Ejecuté la compilación con `npm run build` en `nest.core.view.security`, que confirmó la corrección de TypeScript tras un ajuste en el manejo del tipo de respuesta; la compilación TypeScript pasó.
- El build completo falló por la verificación de budgets de Angular (`bundle initial exceeded maximum budget`), por lo que no se generó un artefacto final de producción.
- No se agregaron ni ejecutaron tests unitarios automáticos en esta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ccbfd3a88333b9e618c9d4dfa30b)