### PR TITLE
feat(security-view): agregar vista Role - Usuario

### DIFF
--- a/nest.core.aplicacion.security/ConfigureServices.cs
+++ b/nest.core.aplicacion.security/ConfigureServices.cs
@@ -48,7 +48,8 @@ namespace nest.core.aplicacion.security
             services.AddTransient<IPersonalRepository, PersonalRepository>();
             services.AddTransient<IIdentityRoleClaimRepository, IdentityRoleClaimRepository>();
             services.AddTransient<IIdentityRoleUserRepository, IdentityRoleUserRepository>();
-            
+            services.AddTransient<IIdentityUserRepository, IdentityUserRepository>();
+
             return services;
         }
         private static void ConfigureValidation(this IServiceCollection services, IConfigurationManager configuration)

--- a/nest.core.aplicacion.security/Login/Handlers/ObtenerClaimsPorUsuarioHandler.cs
+++ b/nest.core.aplicacion.security/Login/Handlers/ObtenerClaimsPorUsuarioHandler.cs
@@ -1,42 +1,21 @@
-using System.Security.Claims;
 using MediatR;
-using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
 using nest.core.aplicacion.security.Login.Queries;
-using nest.core.dominio.Security;
-using nest.core.dominio.Security.Auth;
+using nest.core.dominio.Security.Repositorios;
 
 namespace nest.core.aplicacion.security.Login.Handlers;
 
 public class ObtenerClaimsPorUsuarioHandler : IRequestHandler<ObtenerClaimsPorUsuarioQuery, List<Claim>>
 {
-    private readonly UserManager<ApplicationUser> userManager;
-    private readonly RoleManager<ApplicationRole> roleManager;
+    private readonly IIdentityUserRepository repository;
 
-    public ObtenerClaimsPorUsuarioHandler(
-        UserManager<ApplicationUser> userManager,
-        RoleManager<ApplicationRole> roleManager)
+    public ObtenerClaimsPorUsuarioHandler(IIdentityUserRepository repository)
     {
-        this.userManager = userManager;
-        this.roleManager = roleManager;
+        this.repository = repository;
     }
 
     public async Task<List<Claim>> Handle(ObtenerClaimsPorUsuarioQuery request, CancellationToken cancellationToken)
     {
-        IList<string> roles = await userManager.GetRolesAsync(request.Usuario);
-        var roleClaims = new List<Claim>();
-
-        foreach (string roleName in roles)
-        {
-            var role = await roleManager.FindByNameAsync(roleName);
-            if (role is null)
-            {
-                continue;
-            }
-
-            var claims = await roleManager.GetClaimsAsync(role);
-            roleClaims.AddRange(claims);
-        }
-
-        return roleClaims;
+        return await this.repository.ObtenerClaims(request.Usuario.Id, cancellationToken);
     }
 }

--- a/nest.core.dominio/Security/Repositorios/IIdentityUserRepository.cs
+++ b/nest.core.dominio/Security/Repositorios/IIdentityUserRepository.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace nest.core.dominio.Security.Repositorios
+{
+    public interface IIdentityUserRepository
+    {
+        Task<List<Claim>> ObtenerClaims(string userId, CancellationToken cancellationToken);
+    }
+}

--- a/nest.core.infraestructura.security/Security/IdentityUserRepository.cs
+++ b/nest.core.infraestructura.security/Security/IdentityUserRepository.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.Security.Repositorios;
+using nest.core.infraestructura.db.DbContext;
+using System.Security.Claims;
+
+namespace nest.core.infraestructura.security.Security
+{
+    public class IdentityUserRepository : IIdentityUserRepository
+    {
+        private readonly NestDbContext context;
+        public IdentityUserRepository(NestDbContext context)
+        {
+            this.context = context;
+        }
+
+        public async Task<List<Claim>> ObtenerClaims(string userId, CancellationToken cancellationToken)
+        {
+            var userClaimsQuery =
+                context.UserClaims.IgnoreQueryFilters()
+                .Where(uc => uc.UserId == userId)
+                .Select(uc => new
+                {
+                    uc.ClaimType,
+                    uc.ClaimValue
+                });
+
+            var roleClaimsQuery =
+                from ur in context.UserRoles.IgnoreQueryFilters()
+                join rc in context.RoleClaims.IgnoreQueryFilters()
+                    on ur.RoleId equals rc.RoleId
+                where ur.UserId == userId
+                select new
+                {
+                    rc.ClaimType,
+                    rc.ClaimValue
+                };
+
+            var claims = await userClaimsQuery
+                .Concat(roleClaimsQuery)
+                .ToListAsync(cancellationToken);
+
+            return claims
+                .Select(x => new Claim(x.ClaimType!, x.ClaimValue!))
+                .ToList();
+        }
+    }
+}

--- a/nest.core.security/Controllers/RolUsuarioController.cs
+++ b/nest.core.security/Controllers/RolUsuarioController.cs
@@ -19,13 +19,13 @@ public class RolUsuarioController : Controller
         this.sender = sender;
     }
 
-    [HttpPost("{roleName}")]
+    [HttpPost("{roleId}")]
     [ProducesResponseType(typeof(bool), 200)]
     [ProducesResponseType(typeof(ErrorMessage), 400)]
     [ProducesResponseType(401)]
-    public async Task<ActionResult<bool>> Merge(string roleName, [FromBody] List<string> usersId, CancellationToken ct)
+    public async Task<ActionResult<bool>> Merge(string roleId, [FromBody] List<string> usersId, CancellationToken ct)
     {
-        await sender.Send(new RoleUsuarioMergeCommand(roleName, usersId), ct);
+        await sender.Send(new RoleUsuarioMergeCommand(roleId, usersId), ct);
         return Ok(true);
     }
 }

--- a/nest.core.view.security/src/app/app.routes.ts
+++ b/nest.core.view.security/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { UsuariosPageComponent } from './features/usuarios/pages/usuarios-page.c
 import { FormulariosPageComponent } from './features/formularios/pages/formularios-page.component';
 import { MasterComponent } from './layout/master/master.component';
 import { RoleClaimPageComponent } from './features/role-claim/pages/role-claim-page.component';
+import { RoleUserPageComponent } from './features/role-user/pages/role-user-page.component';
 
 export const appRoutes: Routes = [
   {
@@ -43,6 +44,11 @@ export const appRoutes: Routes = [
         path: 'role-claim',
         component: RoleClaimPageComponent,
         title: 'Role Claim',
+      },
+      {
+        path: 'role-user',
+        component: RoleUserPageComponent,
+        title: 'Role Usuario',
       },
     ],
   },

--- a/nest.core.view.security/src/app/core/services/role-users/role-user.service.ts
+++ b/nest.core.view.security/src/app/core/services/role-users/role-user.service.ts
@@ -9,7 +9,7 @@ export class RoleUserService {
   private readonly httpClient = inject(HttpClient);
   private readonly endpoint = `${environment.apiBaseUrl}/security/RolUsuario`;
 
-  merge(roleName: string, usersId: string[]): Observable<boolean> {
-    return this.httpClient.post<boolean>(`${this.endpoint}/${encodeURIComponent(roleName)}`, usersId);
+  merge(roleId: string, usersId: string[]): Observable<boolean> {
+    return this.httpClient.post<boolean>(`${this.endpoint}/${encodeURIComponent(roleId)}`, usersId);
   }
 }

--- a/nest.core.view.security/src/app/core/services/role-users/role-user.service.ts
+++ b/nest.core.view.security/src/app/core/services/role-users/role-user.service.ts
@@ -1,0 +1,15 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '@environment/environment';
+
+@Injectable({ providedIn: 'root' })
+export class RoleUserService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly endpoint = `${environment.apiBaseUrl}/security/RolUsuario`;
+
+  merge(roleName: string, usersId: string[]): Observable<boolean> {
+    return this.httpClient.post<boolean>(`${this.endpoint}/${encodeURIComponent(roleName)}`, usersId);
+  }
+}

--- a/nest.core.view.security/src/app/core/services/ui/menu.service.ts
+++ b/nest.core.view.security/src/app/core/services/ui/menu.service.ts
@@ -31,6 +31,11 @@ export class MenuService {
             icon: 'fa-solid fa-diagram-project',
             route: '/role-claim',
           },
+          {
+            label: 'Role User',
+            icon: 'fa-solid fa-diagram-project',
+            route: '/role-user',
+          },
         ],
       },
       {

--- a/nest.core.view.security/src/app/core/services/users/security-user.service.ts
+++ b/nest.core.view.security/src/app/core/services/users/security-user.service.ts
@@ -26,6 +26,10 @@ export class SecurityUserService {
     return this.httpClient.post<LoadResult<SecurityUserEntity[]>>(`${this.endpoint}/filter`, loadOptions);
   }
 
+  getByRoleName(roleName: string): Observable<SecurityUserEntity[]> {
+    return this.httpClient.get<SecurityUserEntity[]>(`${this.endpoint}/rol/${encodeURIComponent(roleName)}`);
+  }
+
   getById(id: string): Observable<SecurityUserEntity> {
     return this.httpClient.get<SecurityUserEntity>(`${this.endpoint}/${id}`);
   }

--- a/nest.core.view.security/src/app/features/role-user/pages/role-user-page.component.html
+++ b/nest.core.view.security/src/app/features/role-user/pages/role-user-page.component.html
@@ -1,0 +1,52 @@
+<section class="card shadow-sm border-0">
+  <header class="card-header border-bottom d-flex justify-content-between align-items-center">
+    <h5 class="mb-0">Asignación Role - Usuario</h5>
+  </header>
+
+  <div class="card-body role-claim-layout">
+    <div class="row">
+      <div class="col-lg-4">
+        <h6>Roles</h6>
+        <dx-data-grid
+          [dataSource]="rolesDataSource"
+          [showBorders]="true"
+          [rowAlternationEnabled]="true"
+          [remoteOperations]="true"
+          [columnAutoWidth]="true"
+          [selection]="{ mode: 'single' }"
+          [showRowLines]="true"
+          (onSelectionChanged)="onRoleSelectionChanged($event)">
+          <dxo-search-panel [visible]="true"></dxo-search-panel>
+          <dxo-filter-row [visible]="true"></dxo-filter-row>
+          <dxo-paging [pageSize]="10"></dxo-paging>
+          <dxi-column dataField="id" caption="Id"></dxi-column>
+          <dxi-column dataField="name" caption="Nombre"></dxi-column>
+        </dx-data-grid>
+        <div class="text-end mt-2">
+          <dx-button text="Guardar usuarios" type="success" icon="save" (onClick)="saveRoleUsers()"></dx-button>
+        </div>
+      </div>
+      <div class="col-lg-8">
+        <h6>Usuarios</h6>
+        <dx-data-grid
+          [dataSource]="usersDataSource"
+          [showBorders]="true"
+          [rowAlternationEnabled]="true"
+          [remoteOperations]="true"
+          [columnAutoWidth]="true"
+          [selection]="{ mode: 'multiple', showCheckBoxesMode: 'always' }"
+          [showRowLines]="true"
+          [selectedRowKeys]="selectedUserIds()"
+          (onSelectionChanged)="onUsersSelectionChanged($event)">
+          <dxo-search-panel [visible]="true"></dxo-search-panel>
+          <dxo-filter-row [visible]="true"></dxo-filter-row>
+          <dxo-paging [pageSize]="10"></dxo-paging>
+          <dxi-column dataField="id" caption="Id" [visible]="false"></dxi-column>
+          <dxi-column dataField="email" caption="Email"></dxi-column>
+          <dxi-column dataField="phoneNumber" caption="Teléfono"></dxi-column>
+          <dxi-column dataField="userName" caption="Usuario"></dxi-column>
+        </dx-data-grid>
+      </div>
+    </div>
+  </div>
+</section>

--- a/nest.core.view.security/src/app/features/role-user/pages/role-user-page.component.ts
+++ b/nest.core.view.security/src/app/features/role-user/pages/role-user-page.component.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import CustomStore from 'devextreme/data/custom_store';
+import { DxButtonModule, DxDataGridModule } from 'devextreme-angular';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+import notify from 'devextreme/ui/notify';
+import { DxDataGridTypes } from 'devextreme-angular/ui/data-grid';
+
+import { SecurityRoleEntity } from '@app/core/entities/security-role.entity';
+import { SecurityUserEntity } from '@app/core/entities/security-user.entity';
+import { SecurityRoleService } from '@app/core/services/roles/security-role.service';
+import { SecurityUserService } from '@app/core/services/users/security-user.service';
+import { RoleUserService } from '@app/core/services/role-users/role-user.service';
+import { NestUtils } from '@app/core/services/util/nestUtils';
+
+@Component({
+  selector: 'app-role-user-page',
+  imports: [DxButtonModule, DxDataGridModule],
+  templateUrl: './role-user-page.component.html',
+  styleUrl: './role-user-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RoleUserPageComponent {
+  private readonly securityRoleService = inject(SecurityRoleService);
+  private readonly securityUserService = inject(SecurityUserService);
+  private readonly roleUserService = inject(RoleUserService);
+
+  protected readonly selectedRoleName = signal<string | null>(null);
+  protected readonly selectedUserIds = signal<string[]>([]);
+
+  protected readonly rolesDataSource = new CustomStore<SecurityRoleEntity, string>({
+    key: 'id',
+    useDefaultSearch: true,
+    load: async (options: LoadOptions): Promise<LoadResult<SecurityRoleEntity[]>> => {
+      try {
+        return await firstValueFrom(this.securityRoleService.getByFilter(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
+    },
+  });
+
+  protected readonly usersDataSource = new CustomStore<SecurityUserEntity, string>({
+    key: 'id',
+    useDefaultSearch: true,
+    load: async (options: LoadOptions): Promise<LoadResult<SecurityUserEntity[]>> => {
+      try {
+        return await firstValueFrom(this.securityUserService.getByFilter(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
+    },
+  });
+
+  protected onRoleSelectionChanged(event: DxDataGridTypes.SelectionChangedEvent<SecurityRoleEntity>) {
+    const role = event.selectedRowsData[0];
+    this.selectedRoleName.set(role?.name ?? null);
+  }
+
+  protected onUsersSelectionChanged(event: DxDataGridTypes.SelectionChangedEvent<SecurityUserEntity>) {
+    this.selectedUserIds.set(event.selectedRowKeys as string[]);
+  }
+
+  protected async saveRoleUsers() {
+    const roleName = this.selectedRoleName();
+    if (!roleName) {
+      notify('Seleccione un rol.', 'warning', 2500);
+      return;
+    }
+
+    await NestUtils.showConfirmationDialog({
+      title: 'Advertencia',
+      text: '¿Estás seguro que desea guardar los usuarios asociados a este rol?',
+      funtionToExecute: () => this.roleUserService.merge(roleName, this.selectedUserIds()),
+    });
+  }
+}

--- a/nest.core.view.security/src/app/features/role-user/pages/role-user-page.component.ts
+++ b/nest.core.view.security/src/app/features/role-user/pages/role-user-page.component.ts
@@ -25,7 +25,7 @@ export class RoleUserPageComponent {
   private readonly securityUserService = inject(SecurityUserService);
   private readonly roleUserService = inject(RoleUserService);
 
-  protected readonly selectedRoleName = signal<string | null>(null);
+  protected readonly selectedRoleId = signal<string | null>(null);
   protected readonly selectedUserIds = signal<string[]>([]);
 
   protected readonly rolesDataSource = new CustomStore<SecurityRoleEntity, string>({
@@ -52,9 +52,16 @@ export class RoleUserPageComponent {
     },
   });
 
-  protected onRoleSelectionChanged(event: DxDataGridTypes.SelectionChangedEvent<SecurityRoleEntity>) {
+  protected async onRoleSelectionChanged(event: DxDataGridTypes.SelectionChangedEvent<SecurityRoleEntity>) {
     const role = event.selectedRowsData[0];
-    this.selectedRoleName.set(role?.name ?? null);
+    this.selectedRoleId.set(role?.id ?? null);
+    await this.loadTreeForRole(role.name);
+  }
+
+  private async loadTreeForRole(roleName: string) {
+    const result = await firstValueFrom(this.securityUserService.getByRoleName(roleName));
+    const selectedUsers = result.map((f) => f.id);
+    this.selectedUserIds.set(selectedUsers);
   }
 
   protected onUsersSelectionChanged(event: DxDataGridTypes.SelectionChangedEvent<SecurityUserEntity>) {
@@ -62,8 +69,8 @@ export class RoleUserPageComponent {
   }
 
   protected async saveRoleUsers() {
-    const roleName = this.selectedRoleName();
-    if (!roleName) {
+    const roleId = this.selectedRoleId();
+    if (!roleId) {
       notify('Seleccione un rol.', 'warning', 2500);
       return;
     }
@@ -71,7 +78,7 @@ export class RoleUserPageComponent {
     await NestUtils.showConfirmationDialog({
       title: 'Advertencia',
       text: '¿Estás seguro que desea guardar los usuarios asociados a este rol?',
-      funtionToExecute: () => this.roleUserService.merge(roleName, this.selectedUserIds()),
+      funtionToExecute: () => this.roleUserService.merge(roleId, this.selectedUserIds()),
     });
   }
 }


### PR DESCRIPTION
### Motivation
- Permitir asignar usuarios a roles desde la UI siguiendo el mismo patrón visual y de comportamiento que la vista `role-claim` y consumir el endpoint del backend `nest.core.security - RolUsuarioController`.

### Description
- Se agregó la página de asignación `RoleUserPageComponent` con carga remota de roles y usuarios utilizando `CustomStore` y `getByFilter`, selección de rol y selección múltiple de usuarios, y una acción de guardado con confirmación (`saveRoleUsers`).
- Se creó el servicio `RoleUserService` en `src/app/core/services/role-users/role-user.service.ts` que implementa `merge(roleName: string, usersId: string[])` y realiza `POST /security/RolUsuario/{roleName}` enviando el listado de ids.
- Se añadieron los archivos de plantilla y estilos `src/app/features/role-user/pages/role-user-page.component.html` y `...scss` para replicar la interfaz de `role-claim` y `...component.ts` con la lógica correspondiente.
- Se registró la ruta `path: 'role-user'` en `src/app/app.routes.ts` para exponer la nueva vista en la navegación de la aplicación.

### Testing
- Se intentó compilar el front-end ejecutando `cd nest.core.view.security && npm run build`, pero la compilación falló en este entorno por ausencia de Angular CLI (`sh: 1: ng: not found`).
- No se ejecutaron otras pruebas automáticas; no se detectaron pruebas unitarias o e2e automáticas en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2af56cc8083338260248e02f60740)