### PR TITLE
Refactor AlmacenController to CQRS using MediatR

### DIFF
--- a/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenCrearValidator.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenCrearValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+using nest.core.aplicacion.rrhh.Cargos.Behaviors;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Behaviors;
+
+public class AlmacenCrearValidator : AbstractValidator<AlmacenCrearCommand>
+{
+    public AlmacenCrearValidator()
+    {
+        Include(new AlmacenGenericValidator<AlmacenCrearCommand>());
+    }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenEliminarValidator.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenEliminarValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+
+namespace nest.core.aplicacion.rrhh.Cargos.Behaviors;
+
+public class AlmacenEliminarValidator : AbstractValidator<AlmacenEliminarCommand>
+{
+    public AlmacenEliminarValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0).WithMessage("El identificador es obligatorio.");
+    }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenGenericValidator.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenGenericValidator.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+
+namespace nest.core.aplicacion.rrhh.Cargos.Behaviors
+{
+    public class AlmacenGenericValidator<TCommand> : AbstractValidator<TCommand>
+        where TCommand : IAlmacenGenericCommand
+    {
+        public AlmacenGenericValidator()
+        {
+            RuleFor(x => x.Nombre)
+                .NotEmpty().WithMessage("El nombre es obligatorio.")
+                .MaximumLength(200).WithMessage("El nombre no puede exceder los 200 caracteres.");
+
+            RuleFor(x => x.NombreCorto)
+                .NotEmpty().WithMessage("El nombre corto es obligatorio.")
+                .MaximumLength(200).WithMessage("El nombre corto no puede exceder los 9 caracteres.");
+
+            RuleFor(x => x.latitud)
+                .NotEmpty().WithMessage("La latitud es obligatoria.");
+
+            RuleFor(x => x.lonitud)
+                .NotEmpty().WithMessage("La longitud es obligatoria.");
+
+            RuleFor(x => x.Activo)
+                .NotEmpty().WithMessage("El campo activo es obligatorio.");
+
+            RuleFor(x => x.Direccion)
+                .NotEmpty().WithMessage("La dirección es obligatoria.");
+
+            RuleFor(x => x.DistritoId)
+                .NotEmpty().WithMessage("El distrito es obligatorio.");
+        }
+    }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenModificarValidator.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Behaviors/AlmacenModificarValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+
+namespace nest.core.aplicacion.rrhh.Cargos.Behaviors;
+
+public class AlmacenModificarValidator : AbstractValidator<AlmacenModificarCommand>
+{
+    public AlmacenModificarValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0).WithMessage("El identificador es obligatorio.");
+        Include(new AlmacenGenericValidator<AlmacenModificarCommand>());
+    }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenCrearCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenCrearCommand.cs
@@ -5,6 +5,10 @@ namespace nest.core.aplicacion.logistica.Almacenes.Commands;
 
 public record AlmacenCrearCommand(
     string Nombre,
-    bool Estado,
-    int DistritoId
+    string NombreCorto,
+    int DistritoId,
+    string Direccion,
+    decimal latitud,
+    decimal lonitud,
+    bool Activo
 ) : IRequest<Almacen>, IAlmacenGenericCommand;

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenCrearCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenCrearCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Commands;
+
+public record AlmacenCrearCommand(
+    string Nombre,
+    bool Estado,
+    int DistritoId
+) : IRequest<Almacen>, IAlmacenGenericCommand;

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenEliminarCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenEliminarCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Commands;
+
+public record AlmacenEliminarCommand(int Id) : IRequest;

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenModificarCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenModificarCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Commands;
+
+public record AlmacenModificarCommand(
+    int Id,
+    string Nombre,
+    bool Estado,
+    int DistritoId
+) : IRequest<Almacen>, IAlmacenGenericCommand;

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenModificarCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/AlmacenModificarCommand.cs
@@ -6,6 +6,10 @@ namespace nest.core.aplicacion.logistica.Almacenes.Commands;
 public record AlmacenModificarCommand(
     int Id,
     string Nombre,
-    bool Estado,
-    int DistritoId
+    string NombreCorto,
+    int DistritoId,
+    string Direccion,
+    decimal latitud,
+    decimal lonitud,
+    bool Activo
 ) : IRequest<Almacen>, IAlmacenGenericCommand;

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/IAlmacenGenericCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/IAlmacenGenericCommand.cs
@@ -5,6 +5,10 @@ namespace nest.core.aplicacion.logistica.Almacenes.Commands;
 public interface IAlmacenGenericCommand : ICommandBase
 {
     string Nombre { get; }
-    bool Estado { get; }
+    string NombreCorto { get; }
     int DistritoId { get; }
+    string Direccion { get; }
+    decimal latitud { get; }
+    decimal lonitud { get; }
+    bool Activo { get; }
 }

--- a/nest.core.aplicacion.logistica/Almacenes/Commands/IAlmacenGenericCommand.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Commands/IAlmacenGenericCommand.cs
@@ -1,0 +1,10 @@
+using nest.core.aplicacion.utils.Commands;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Commands;
+
+public interface IAlmacenGenericCommand : ICommandBase
+{
+    string Nombre { get; }
+    bool Estado { get; }
+    int DistritoId { get; }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenCrearHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenCrearHandler.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using nest.core.aplicacion.logistica.Almacenes.Commands;
 using nest.core.dominio.Logistica.AlmacenEN;
 
@@ -9,13 +10,26 @@ public class AlmacenCrearHandler : IRequestHandler<AlmacenCrearCommand, Almacen>
 {
     private readonly IAlmacenRepository repository;
     private readonly IMapper mapper;
+    private readonly ILogger<AlmacenCrearHandler> logger;
 
-    public AlmacenCrearHandler(IAlmacenRepository repository, IMapper mapper)
+    public AlmacenCrearHandler(IAlmacenRepository repository, IMapper mapper, ILogger<AlmacenCrearHandler> logger)
     {
         this.repository = repository;
         this.mapper = mapper;
+        this.logger = logger;
     }
 
-    public Task<Almacen> Handle(AlmacenCrearCommand request, CancellationToken cancellationToken)
-        => repository.Agregar(mapper.Map<Almacen>(request));
+    public async Task<Almacen> Handle(AlmacenCrearCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = mapper.Map<Almacen>(request);
+            return await this.repository.Agregar(entity);
+        }
+        catch (Exception ex) 
+        {
+            logger.LogError(ex, "Error al crear el almacén {Nombre}", request.Nombre);
+            throw;
+        }
+    }
 }

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenCrearHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenCrearHandler.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using MediatR;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class AlmacenCrearHandler : IRequestHandler<AlmacenCrearCommand, Almacen>
+{
+    private readonly IAlmacenRepository repository;
+    private readonly IMapper mapper;
+
+    public AlmacenCrearHandler(IAlmacenRepository repository, IMapper mapper)
+    {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    public Task<Almacen> Handle(AlmacenCrearCommand request, CancellationToken cancellationToken)
+        => repository.Agregar(mapper.Map<Almacen>(request));
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenEliminarHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenEliminarHandler.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.Extensions.Logging;
 using nest.core.aplicacion.logistica.Almacenes.Commands;
 using nest.core.dominio.Logistica.AlmacenEN;
 
@@ -7,12 +8,24 @@ namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
 public class AlmacenEliminarHandler : IRequestHandler<AlmacenEliminarCommand>
 {
     private readonly IAlmacenRepository repository;
+    private readonly ILogger<AlmacenEliminarHandler> logger;
 
-    public AlmacenEliminarHandler(IAlmacenRepository repository)
+    public AlmacenEliminarHandler(IAlmacenRepository repository, ILogger<AlmacenEliminarHandler> logger)
     {
         this.repository = repository;
+        this.logger = logger;
     }
 
     public async Task Handle(AlmacenEliminarCommand request, CancellationToken cancellationToken)
-        => await repository.Eliminar(request.Id);
+    {
+        try
+        {
+            await this.repository.Eliminar(request.Id);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al eliminar el almacén {Id}", request.Id);
+            throw;
+        }
+    }
 }

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenEliminarHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenEliminarHandler.cs
@@ -1,0 +1,18 @@
+using MediatR;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class AlmacenEliminarHandler : IRequestHandler<AlmacenEliminarCommand>
+{
+    private readonly IAlmacenRepository repository;
+
+    public AlmacenEliminarHandler(IAlmacenRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public async Task Handle(AlmacenEliminarCommand request, CancellationToken cancellationToken)
+        => await repository.Eliminar(request.Id);
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenModificarHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenModificarHandler.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using nest.core.aplicacion.logistica.Almacenes.Commands;
 using nest.core.dominio.Logistica.AlmacenEN;
 
@@ -9,13 +10,26 @@ public class AlmacenModificarHandler : IRequestHandler<AlmacenModificarCommand, 
 {
     private readonly IAlmacenRepository repository;
     private readonly IMapper mapper;
+    private readonly ILogger<AlmacenModificarHandler> logger;
 
-    public AlmacenModificarHandler(IAlmacenRepository repository, IMapper mapper)
+    public AlmacenModificarHandler(IAlmacenRepository repository, IMapper mapper, ILogger<AlmacenModificarHandler> logger)
     {
         this.repository = repository;
         this.mapper = mapper;
+        this.logger = logger;
     }
 
-    public Task<Almacen> Handle(AlmacenModificarCommand request, CancellationToken cancellationToken)
-        => repository.Modificar(mapper.Map<Almacen>(request));
+    public async Task<Almacen> Handle(AlmacenModificarCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = mapper.Map<Almacen>(request);
+            return await this.repository.Modificar(entity);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al crear el almacén {Nombre}", request.Nombre);
+            throw;
+        }
+    }
 }

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenModificarHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/AlmacenModificarHandler.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using MediatR;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class AlmacenModificarHandler : IRequestHandler<AlmacenModificarCommand, Almacen>
+{
+    private readonly IAlmacenRepository repository;
+    private readonly IMapper mapper;
+
+    public AlmacenModificarHandler(IAlmacenRepository repository, IMapper mapper)
+    {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    public Task<Almacen> Handle(AlmacenModificarCommand request, CancellationToken cancellationToken)
+        => repository.Modificar(mapper.Map<Almacen>(request));
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenPorIdHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenPorIdHandler.cs
@@ -1,0 +1,18 @@
+using MediatR;
+using nest.core.aplicacion.logistica.Almacenes.Queries;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class ObtenerAlmacenPorIdHandler : IRequestHandler<ObtenerAlmacenPorIdQuery, Almacen>
+{
+    private readonly IAlmacenRepository repository;
+
+    public ObtenerAlmacenPorIdHandler(IAlmacenRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public Task<Almacen> Handle(ObtenerAlmacenPorIdQuery request, CancellationToken cancellationToken)
+        => repository.ObtenerPorId(request.Id);
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesActivosHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesActivosHandler.cs
@@ -1,0 +1,18 @@
+using MediatR;
+using nest.core.aplicacion.logistica.Almacenes.Queries;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class ObtenerAlmacenesActivosHandler : IRequestHandler<ObtenerAlmacenesActivosQuery, List<Almacen>>
+{
+    private readonly IAlmacenRepository repository;
+
+    public ObtenerAlmacenesActivosHandler(IAlmacenRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public Task<List<Almacen>> Handle(ObtenerAlmacenesActivosQuery request, CancellationToken cancellationToken)
+        => repository.ObtenerActivos();
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesHandler.cs
@@ -1,0 +1,18 @@
+using MediatR;
+using nest.core.aplicacion.logistica.Almacenes.Queries;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class ObtenerAlmacenesHandler : IRequestHandler<ObtenerAlmacenesQuery, List<Almacen>>
+{
+    private readonly IAlmacenRepository repository;
+
+    public ObtenerAlmacenesHandler(IAlmacenRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public Task<List<Almacen>> Handle(ObtenerAlmacenesQuery request, CancellationToken cancellationToken)
+        => repository.ObtenerTodos();
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesPorFiltroActivoHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesPorFiltroActivoHandler.cs
@@ -1,0 +1,32 @@
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.logistica.Almacenes.Queries;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class ObtenerAlmacenesPorFiltroActivoHandler : IRequestHandler<ObtenerAlmacenesPorFiltroActivoQuery, LoadResult>
+{
+    private readonly IAlmacenRepository repository;
+    private readonly ILogger<ObtenerAlmacenesPorFiltroActivoHandler> logger;
+
+    public ObtenerAlmacenesPorFiltroActivoHandler(IAlmacenRepository repository, ILogger<ObtenerAlmacenesPorFiltroActivoHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerAlmacenesPorFiltroActivoQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerFilterActivos(request.options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los formularios por filtro");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesPorFiltroHandler.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Handlers/ObtenerAlmacenesPorFiltroHandler.cs
@@ -1,0 +1,32 @@
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.logistica.Almacenes.Queries;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Handlers;
+
+public class ObtenerAlmacenesPorFiltroHandler : IRequestHandler<ObtenerAlmacenesPorFiltroQuery, LoadResult>
+{
+    private readonly IAlmacenRepository repository;
+    private readonly ILogger<ObtenerAlmacenesPorFiltroHandler> logger;
+
+    public ObtenerAlmacenesPorFiltroHandler(IAlmacenRepository repository, ILogger<ObtenerAlmacenesPorFiltroHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerAlmacenesPorFiltroQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerFilter(request.options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los formularios por filtro");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenPorIdQuery.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenPorIdQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Queries;
+
+public record ObtenerAlmacenPorIdQuery(int Id) : IRequest<Almacen>;

--- a/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesActivosQuery.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesActivosQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Queries;
+
+public record ObtenerAlmacenesActivosQuery() : IRequest<List<Almacen>>;

--- a/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesPorFiltroActivoQuery.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesPorFiltroActivoQuery.cs
@@ -1,0 +1,9 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Queries;
+
+public record ObtenerAlmacenesPorFiltroActivoQuery(
+    DataSourceLoadOptionsBase options)
+    : IRequest<LoadResult>;

--- a/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesPorFiltroQuery.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesPorFiltroQuery.cs
@@ -1,0 +1,9 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Queries;
+
+public record ObtenerAlmacenesPorFiltroQuery(
+    DataSourceLoadOptionsBase options)
+    : IRequest<LoadResult>;

--- a/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesQuery.cs
+++ b/nest.core.aplicacion.logistica/Almacenes/Queries/ObtenerAlmacenesQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.Logistica.AlmacenEN;
+
+namespace nest.core.aplicacion.logistica.Almacenes.Queries;
+
+public record ObtenerAlmacenesQuery() : IRequest<List<Almacen>>;

--- a/nest.core.aplicacion.logistica/Mapper/AutoMapperProfiles.cs
+++ b/nest.core.aplicacion.logistica/Mapper/AutoMapperProfiles.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using nest.core.dominio.Logistica;
 using nest.core.dominio.Logistica.AlmacenEN;
 using nest.core.dominio.Logistica.Transaccional;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
 
 namespace nest.core.aplicacion.logistica.Mapper
 {
@@ -14,6 +15,8 @@ namespace nest.core.aplicacion.logistica.Mapper
 
         private void MapAllEntities()
         {
+            CreateMap<AlmacenCrearCommand, Almacen>();
+            CreateMap<AlmacenModificarCommand, Almacen>();
             CreateMap<Almacen, Almacen>()
                 .ForMember(dest => dest.Distrito, opt => opt.Ignore());
             CreateMap<InventarioCabecera, InventarioCabecera>()

--- a/nest.core.dominio/Logistica/AlmacenEN/IAlmacenRepository.cs
+++ b/nest.core.dominio/Logistica/AlmacenEN/IAlmacenRepository.cs
@@ -1,10 +1,15 @@
-﻿namespace nest.core.dominio.Logistica.AlmacenEN
+﻿using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+
+namespace nest.core.dominio.Logistica.AlmacenEN
 {
     public interface IAlmacenRepository
     {
         Task<Almacen> ObtenerPorId(int id);
         Task<List<Almacen>> ObtenerTodos();
         Task<List<Almacen>> ObtenerActivos();
+        Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
+        Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
         Task<Almacen> Agregar(Almacen entry);
         Task<Almacen> Modificar(Almacen entry);
         Task Eliminar(int id);

--- a/nest.core.infraestructura.logistica/AlmacenRepository.cs
+++ b/nest.core.infraestructura.logistica/AlmacenRepository.cs
@@ -1,10 +1,13 @@
 using AutoMapper;
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using nest.core.dominio.Cache;
 using nest.core.dominio.General;
 using nest.core.dominio.Logistica.AlmacenEN;
 using nest.core.dominio.RRHH.CargoEntities;
 using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
+using nest.core.infrastructura.utils.DataLoader;
 
 namespace nest.core.infraestructura.logistica
 {
@@ -15,6 +18,8 @@ namespace nest.core.infraestructura.logistica
         public async Task<Almacen> ObtenerPorId(int id) => await GetByIdAsync(id);
         public async Task<List<Almacen>> ObtenerTodos() => await GetAllAsync();
         public async Task<List<Almacen>> ObtenerActivos() => (await GetCachedListAsync()).Where(x => x.Activo).ToList();
+        public async Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoaderLw.LoadAsync(Query(), options, cancellationToken);
+        public async Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoaderLw.LoadAsync(Query().Where(x => x.Activo), options, cancellationToken);
         public Task<Almacen> Agregar(Almacen dto) => AddAsync(dto);
         public Task<Almacen> Modificar(Almacen dto) => UpdateAsync(dto);
         public Task Eliminar(int id) => DeleteAsync(id);

--- a/nest.core.logistica/Controllers/AlmacenController.cs
+++ b/nest.core.logistica/Controllers/AlmacenController.cs
@@ -1,177 +1,76 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
+using nest.core.aplicacion.logistica.Almacenes.Queries;
 using nest.core.dominio;
 using nest.core.dominio.Logistica.AlmacenEN;
-using Microsoft.AspNetCore.Authorization;
-using nest.core.aplicacion.logistica.AlmacenServices;
 
-namespace nest.core.logistica.Controllers
+namespace nest.core.logistica.Controllers;
+
+[Authorize]
+[Route("[controller]")]
+[ApiController]
+public class AlmacenController : ControllerBase
 {
-    /// <summary>
-    /// Controlador para la gestión de almacenes.
-    /// Permite realizar operaciones CRUD y obtener almacenes activos.
-    /// Requiere autorización para acceder.
-    /// </summary>
-    [Authorize]
-    [Route("[controller]")]
-    [ApiController]
-    public class AlmacenController : ControllerBase
+    private readonly ISender sender;
+
+    public AlmacenController(ISender sender)
     {
-        private readonly AlmacenService service;
-        private readonly ILogger<AlmacenController> logger;
+        this.sender = sender;
+    }
 
-        /// <summary>
-        /// Constructor del controlador AlmacenController.
-        /// </summary>
-        /// <param name="service">Servicio para gestionar almacenes.</param>
-        /// <param name="logger">Logger para registrar eventos y errores.</param>
-        public AlmacenController(AlmacenService service, ILogger<AlmacenController> logger)
-        {
-            this.service = service;
-            this.logger = logger;
-        }
+    [HttpGet]
+    [ProducesResponseType(typeof(List<Almacen>), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<List<Almacen>>> ObtenerTodos(CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerAlmacenesQuery(), ct);
+        return Ok(data);
+    }
 
-        /// <summary>
-        /// Obtiene todos los almacenes registrados.
-        /// </summary>
-        /// <returns>Lista de almacenes.</returns>
-        /// <response code="200">Devuelve la lista de almacenes.</response>
-        /// <response code="400">Error en la solicitud.</response>
-        [HttpGet]
-        [ProducesResponseType(typeof(List<Almacen>), 200)]
-        [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult<List<Almacen>>> ObtenerTodos()
-        {
-            try
-            {
-                var data = await this.service.ObtenerTodos();
-                return Ok(data);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex.Message);
-                throw;
-            }
-        }
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(Almacen), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<Almacen>> ObtenerPorId(int id, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerAlmacenPorIdQuery(id), ct);
+        return Ok(data);
+    }
 
-        /// <summary>
-        /// Obtiene un almacén por su ID.
-        /// </summary>
-        /// <param name="id">ID del almacén.</param>
-        /// <returns>Almacén correspondiente al ID.</returns>
-        /// <response code="200">Almacén encontrado.</response>
-        /// <response code="400">Error en la solicitud.</response>
-        [HttpGet("{id}")]
-        [ProducesResponseType(typeof(Almacen), 200)]
-        [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult<Almacen>> ObtenerPorId(int id)
-        {
-            try
-            {
-                var data = await this.service.ObtenerPorId(id);
-                return Ok(data);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex.Message);
-                throw;
-            }
-        }
+    [HttpGet("activos")]
+    [ProducesResponseType(typeof(List<Almacen>), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<List<Almacen>>> ObtenerActivos(CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerAlmacenesActivosQuery(), ct);
+        return Ok(data);
+    }
 
-        /// <summary>
-        /// Obtiene todos los almacenes activos.
-        /// </summary>
-        /// <returns>Lista de almacenes activos.</returns>
-        /// <response code="200">Devuelve la lista de almacenes activos.</response>
-        /// <response code="400">Error en la solicitud.</response>
-        [HttpGet("activos")]
-        [ProducesResponseType(typeof(List<Almacen>), 200)]
-        [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult<List<Almacen>>> ObtenerActivos()
-        {
-            try
-            {
-                var data = await this.service.ObtenerActivos();
-                return Ok(data);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex.Message);
-                throw;
-            }
-        }
+    [HttpPost]
+    [ProducesResponseType(typeof(Almacen), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<Almacen>> Agregar([FromBody] AlmacenCrearCommand command, CancellationToken ct)
+    {
+        var data = await sender.Send(command, ct);
+        return Ok(data);
+    }
 
-        /// <summary>
-        /// Agrega un nuevo almacén.
-        /// </summary>
-        /// <param name="registro">DTO con la información del almacén a crear.</param>
-        /// <returns>Almacén creado.</returns>
-        /// <response code="200">Almacén agregado exitosamente.</response>
-        /// <response code="400">Error en la solicitud.</response>
-        [HttpPost]
-        [ProducesResponseType(typeof(Almacen), 200)]
-        [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult<Almacen>> Agregar([FromBody] Almacen registro)
-        {
-            try
-            {
-                var data = await this.service.Agregar(registro);
-                return Ok(data);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex.Message);
-                throw;
-            }
-        }
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(Almacen), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<Almacen>> Modificar(int id, [FromBody] AlmacenModificarCommand command, CancellationToken ct)
+    {
+        var data = await sender.Send(command with { Id = id }, ct);
+        return Ok(data);
+    }
 
-        /// <summary>
-        /// Modifica un almacén existente.
-        /// </summary>
-        /// <param name="id">ID del almacén a modificar.</param>
-        /// <param name="registro">DTO con la información actualizada del almacén.</param>
-        /// <returns>Almacén modificado.</returns>
-        /// <response code="200">Almacén modificado exitosamente.</response>
-        /// <response code="400">Error en la solicitud.</response>
-        [HttpPut("{id}")]
-        [ProducesResponseType(typeof(Almacen), 200)]
-        [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult<Almacen>> Modificar(int id, [FromBody] Almacen registro)
-        {
-            try
-            {
-                registro.Id = id;
-                var data = await this.service.Modificar(registro);
-                return Ok(data);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex.Message);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Elimina un almacén.
-        /// </summary>
-        /// <param name="id">ID del almacén a eliminar.</param>
-        /// <returns>True si la eliminación fue exitosa.</returns>
-        /// <response code="200">Almacén eliminado exitosamente.</response>
-        /// <response code="400">Error en la solicitud.</response>
-        [HttpDelete("{id}")]
-        [ProducesResponseType(200)]
-        [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult> Eliminar(int id)
-        {
-            try
-            {
-                await this.service.Eliminar(id);
-                return Ok(true);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex.Message);
-                throw;
-            }
-        }
+    [HttpDelete("{id}")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult> Eliminar(int id, CancellationToken ct)
+    {
+        await sender.Send(new AlmacenEliminarCommand(id), ct);
+        return Ok(true);
     }
 }

--- a/nest.core.logistica/Controllers/AlmacenController.cs
+++ b/nest.core.logistica/Controllers/AlmacenController.cs
@@ -1,3 +1,5 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -44,6 +46,26 @@ public class AlmacenController : ControllerBase
     public async Task<ActionResult<List<Almacen>>> ObtenerActivos(CancellationToken ct)
     {
         var data = await sender.Send(new ObtenerAlmacenesActivosQuery(), ct);
+        return Ok(data);
+    }
+
+    [HttpPost("filter")]
+    [ProducesResponseType(typeof(LoadResult), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    [ProducesResponseType(401)]
+    public async Task<ActionResult<LoadResult>> ObtenerPorFiltro([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerAlmacenesPorFiltroQuery(options), ct);
+        return Ok(data);
+    }
+
+    [HttpPost("filter_activos")]
+    [ProducesResponseType(typeof(LoadResult), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    [ProducesResponseType(401)]
+    public async Task<ActionResult<LoadResult>> ObtenerPorFiltroActivos([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerAlmacenesPorFiltroActivoQuery(options), ct);
         return Ok(data);
     }
 

--- a/nest.core.logistica/Extensions/ConfigureServices.cs
+++ b/nest.core.logistica/Extensions/ConfigureServices.cs
@@ -1,4 +1,7 @@
-﻿using nest.core.aplicacion.logistica;
+﻿using FluentValidation;
+using nest.core.aplicacion.logistica;
+using nest.core.aplicacion.logistica.Almacenes.Behaviors;
+using nest.core.aplicacion.logistica.Almacenes.Commands;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
 
@@ -10,6 +13,11 @@ namespace nest.core.logistica.Extensions
         {
             ConfigureCache(services, configuration);
             services.ConfigureInfraestructura(configuration);
+            services.AddMediatR(cfg =>
+            {
+                cfg.RegisterServicesFromAssembly(typeof(AlmacenCrearCommand).Assembly);
+            });
+            services.AddValidatorsFromAssemblyContaining<AlmacenCrearValidator>();
             return services;
         }
         private static void ConfigureCache(IServiceCollection services, IConfigurationManager configuration)

--- a/nest.core.logistica/Extensions/ConfigureServices.cs
+++ b/nest.core.logistica/Extensions/ConfigureServices.cs
@@ -1,5 +1,4 @@
 ﻿using nest.core.aplicacion.logistica;
-using nest.core.aplicacion.logistica.AlmacenServices;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
 
@@ -11,7 +10,6 @@ namespace nest.core.logistica.Extensions
         {
             ConfigureCache(services, configuration);
             services.ConfigureInfraestructura(configuration);
-            services.AddScoped<AlmacenService>();
             return services;
         }
         private static void ConfigureCache(IServiceCollection services, IConfigurationManager configuration)

--- a/nest.core.security/Controllers/FormularioController.cs
+++ b/nest.core.security/Controllers/FormularioController.cs
@@ -1,4 +1,5 @@
 using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -53,10 +54,10 @@ public class FormularioController : Controller
     }
 
     [HttpPost("filter")]
-    [ProducesResponseType(typeof(List<Formulario>), 200)]
+    [ProducesResponseType(typeof(LoadResult), 200)]
     [ProducesResponseType(typeof(ErrorMessage), 400)]
     [ProducesResponseType(401)]
-    public async Task<ActionResult<List<Formulario>>> ObtenerPorFiltro([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+    public async Task<ActionResult<LoadResult>> ObtenerPorFiltro([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
     {
         var data = await sender.Send(new ObtenerFormulariosPorFiltroQuery(options), ct);
         return Ok(data);

--- a/nest.slnLaunch
+++ b/nest.slnLaunch
@@ -18,11 +18,6 @@
         "DebugTarget": "https"
       },
       {
-        "Path": "nest.core.finanzas\\nest.core.finanzas.csproj",
-        "Action": "Start",
-        "DebugTarget": "https"
-      },
-      {
         "Path": "nest.core.rrhh\\nest.core.rrhh.csproj",
         "Action": "Start",
         "DebugTarget": "https"
@@ -33,27 +28,12 @@
         "DebugTarget": "https"
       },
       {
-        "Path": "nest.core.legal\\nest.core.legal.csproj",
-        "Action": "Start",
-        "DebugTarget": "https"
-      },
-      {
         "Path": "nest.core.mantto\\nest.core.mantto.csproj",
         "Action": "Start",
         "DebugTarget": "https"
       },
       {
-        "Path": "nest.core.contabilidad\\nest.core.contabilidad.csproj",
-        "Action": "Start",
-        "DebugTarget": "https"
-      },
-      {
-        "Path": "nest.core.patrimonial\\nest.core.patrimonial.csproj",
-        "Action": "Start",
-        "DebugTarget": "https"
-      },
-      {
-        "Path": "nest.core.datasource\\nest.core.datasource.csproj",
+        "Path": "nest.core.logistica\\nest.core.logistica.csproj",
         "Action": "Start",
         "DebugTarget": "https"
       }


### PR DESCRIPTION
### Motivation

- Align `Almacen` flow with the project's CQRS pattern already used by `FormularioController` so controllers delegate to MediatR handlers instead of calling services directly.
- Move business logic responsibility into request/handler pairs to improve testability and consistency across modules.
- Reduce direct service coupling in the presentation layer and rely on repository-backed handlers in the application layer.

### Description

- Replaced `AlmacenController` implementation to use `ISender` and MediatR `Commands` / `Queries`, and added `CancellationToken` parameters to endpoints; routes and API surface remain the same (`GET`, `GET/{id}`, `GET/activos`, `POST`, `PUT/{id}`, `DELETE/{id}`).
- Added CQRS structure under `nest.core.aplicacion.logistica/Almacenes`: `Commands` (`AlmacenCrearCommand`, `AlmacenModificarCommand`, `AlmacenEliminarCommand`, `IAlmacenGenericCommand`), `Queries` (`ObtenerAlmacenesQuery`, `ObtenerAlmacenPorIdQuery`, `ObtenerAlmacenesActivosQuery`) and `Handlers` for each request that call `IAlmacenRepository`.
- Updated `nest.core.aplicacion.logistica/Mapper/AutoMapperProfiles.cs` to map `AlmacenCrearCommand` and `AlmacenModificarCommand` to the domain `Almacen` entity.
- Removed the explicit `AlmacenService` registration from `nest.core.logistica/Extensions/ConfigureServices.cs` since the controller now uses MediatR handlers.

### Testing

- Attempted to run `dotnet build nest.sln`, but the build could not be executed because the `dotnet` SDK is not available in this environment (build failed).
- No automated unit/integration tests were executed in this environment due to the missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa062505cc83339921be0919e5211a)