### PR TITLE
feat(security-view): agregar mantenimiento de almacenes en nest.core.view.security

### DIFF
--- a/nest.core.view.security/src/app/app.routes.ts
+++ b/nest.core.view.security/src/app/app.routes.ts
@@ -11,6 +11,7 @@ import { RoleClaimPageComponent } from './features/seguridad/role-claim/pages/ro
 import { RoleUserPageComponent } from './features/seguridad/role-user/pages/role-user-page.component';
 import { ModulosPageComponent } from './features/seguridad/modulos/pages/modulos-page.component';
 import { claimGuard } from './core/auth/claim.guard';
+import { AlmacenesPageComponent } from './features/logistica/almacenes/pages/almacenes-page.component';
 
 export const appRoutes: Routes = [
   {
@@ -70,6 +71,13 @@ export const appRoutes: Routes = [
         component: RoleUserPageComponent,
         title: 'Nest | Role Usuario',
         canActivate: [claimGuard('seguridad-rolUsuario')]
+      },
+
+      {
+        path: 'logistica/almacen',
+        component: AlmacenesPageComponent,
+        title: 'Nest | Almacenes',
+        canActivate: [claimGuard('logistica-almacen')]
       },
       {
         path: 'acceso-denegado',

--- a/nest.core.view.security/src/app/core/entities/almacen.entity.ts
+++ b/nest.core.view.security/src/app/core/entities/almacen.entity.ts
@@ -1,0 +1,25 @@
+export interface AlmacenEntity {
+  id: number;
+  empresaId: number;
+  nombre: string;
+  nombreCorto: string;
+  distritoId: number;
+  direccion: string;
+  latitud: number;
+  longitud: number;
+  activo: boolean;
+}
+
+export interface AlmacenCreatePayload {
+  nombre: string;
+  nombreCorto: string;
+  distritoId: number;
+  direccion: string;
+  latitud: number;
+  lonitud: number;
+  activo: boolean;
+}
+
+export interface AlmacenUpdatePayload extends AlmacenCreatePayload {
+  id: number;
+}

--- a/nest.core.view.security/src/app/core/services/logistica/almacenes/almacen.service.ts
+++ b/nest.core.view.security/src/app/core/services/logistica/almacenes/almacen.service.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+
+import { AlmacenCreatePayload, AlmacenEntity, AlmacenUpdatePayload } from '@app/core/entities/almacen.entity';
+import { environment } from '@environment/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AlmacenService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly endpoint = `${environment.apiBaseUrl}/logistica/Almacen`;
+
+  getByFilter(loadOptions: LoadOptions): Observable<LoadResult<AlmacenEntity[]>> {
+    return this.httpClient.post<LoadResult<AlmacenEntity[]>>(`${this.endpoint}/filter`, loadOptions);
+  }
+
+  getById(id: number): Observable<AlmacenEntity> {
+    return this.httpClient.get<AlmacenEntity>(`${this.endpoint}/${id}`);
+  }
+
+  create(payload: AlmacenCreatePayload): Observable<AlmacenEntity> {
+    return this.httpClient.post<AlmacenEntity>(this.endpoint, payload);
+  }
+
+  update(payload: AlmacenUpdatePayload): Observable<AlmacenEntity> {
+    return this.httpClient.put<AlmacenEntity>(`${this.endpoint}/${payload.id}`, payload);
+  }
+
+  delete(id: number): Observable<boolean> {
+    return this.httpClient.delete<boolean>(`${this.endpoint}/${id}`);
+  }
+}

--- a/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.html
+++ b/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.html
@@ -1,0 +1,35 @@
+<section class="card shadow-sm border-0">
+  <header class="card-header border-bottom">
+    <h5 class="mb-0">Mantenimiento de Almacenes</h5>
+  </header>
+
+  <div class="card-body">
+    <dx-data-grid
+      [dataSource]="almacenesDataSource"
+      [showBorders]="true"
+      [columnAutoWidth]="true"
+      [showRowLines]="true"
+      [rowAlternationEnabled]="true"
+      [selection]="{ mode: 'single' }"
+      [remoteOperations]="true">
+      <dxo-search-panel [visible]="true"></dxo-search-panel>
+      <dxo-filter-row [visible]="true"></dxo-filter-row>
+      <dxo-data-grid-header-filter [visible]="true"></dxo-data-grid-header-filter>
+      <dxo-paging [pageSize]="10"></dxo-paging>
+      <dxo-pager [showPageSizeSelector]="true" [allowedPageSizes]="[10, 20, 50]" [showInfo]="true"></dxo-pager>
+      <dxo-editing mode="popup" [allowAdding]="true" [allowUpdating]="true" [allowDeleting]="true" [useIcons]="true">
+        <dxo-popup title="Almacén" [showTitle]="true"></dxo-popup>
+      </dxo-editing>
+
+      <dxi-column dataField="id" [visible]="false" [allowEditing]="false"></dxi-column>
+      <dxi-column dataField="empresaId" caption="Empresa Id" [allowEditing]="false"></dxi-column>
+      <dxi-column dataField="nombre" caption="Nombre" [validationRules]="[{ type: 'required' }]" ></dxi-column>
+      <dxi-column dataField="nombreCorto" caption="Nombre Corto" [validationRules]="[{ type: 'required' }]" ></dxi-column>
+      <dxi-column dataField="distritoId" caption="Distrito Id" dataType="number" [validationRules]="[{ type: 'required' }]" ></dxi-column>
+      <dxi-column dataField="direccion" caption="Dirección" [validationRules]="[{ type: 'required' }]" ></dxi-column>
+      <dxi-column dataField="latitud" caption="Latitud" dataType="number"></dxi-column>
+      <dxi-column dataField="longitud" caption="Longitud" dataType="number"></dxi-column>
+      <dxi-column dataField="activo" caption="Activo" dataType="boolean"></dxi-column>
+    </dx-data-grid>
+  </div>
+</section>

--- a/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.ts
+++ b/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import CustomStore from 'devextreme/data/custom_store';
+import { DxDataGridModule } from 'devextreme-angular';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+
+import { AlmacenCreatePayload, AlmacenEntity } from '@app/core/entities/almacen.entity';
+import { AlmacenService } from '@app/core/services/logistica/almacenes/almacen.service';
+import { NestUtils } from '@app/core/services/util/nestUtils';
+
+@Component({
+  selector: 'app-almacenes-page',
+  imports: [DxDataGridModule],
+  templateUrl: './almacenes-page.component.html',
+  styleUrl: './almacenes-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AlmacenesPageComponent {
+  private readonly almacenService = inject(AlmacenService);
+
+  protected readonly almacenesDataSource = new CustomStore<AlmacenEntity, number>({
+    key: 'id',
+    useDefaultSearch: true,
+    load: async (options: LoadOptions): Promise<LoadResult<AlmacenEntity[]>> => {
+      try {
+        return await firstValueFrom(this.almacenService.getByFilter(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
+    },
+    byKey: async (key: number): Promise<AlmacenEntity> => {
+      return firstValueFrom(this.almacenService.getById(Number(key)));
+    },
+    insert: async (values: Partial<AlmacenEntity>): Promise<AlmacenEntity> => {
+      const payload: AlmacenCreatePayload = {
+        nombre: values.nombre?.trim() ?? '',
+        nombreCorto: values.nombreCorto?.trim() ?? '',
+        distritoId: Number(values.distritoId),
+        direccion: values.direccion?.trim() ?? '',
+        latitud: Number(values.latitud ?? 0),
+        lonitud: Number(values.longitud ?? 0),
+        activo: values.activo ?? true,
+      };
+
+      return await firstValueFrom(this.almacenService.create(payload));
+    },
+    update: async (key: number, values: Partial<AlmacenEntity>): Promise<AlmacenEntity> => {
+      const current = await firstValueFrom(this.almacenService.getById(Number(key)));
+      return await firstValueFrom(
+        this.almacenService.update({
+          id: Number(key),
+          nombre: values.nombre?.trim() ?? current.nombre,
+          nombreCorto: values.nombreCorto?.trim() ?? current.nombreCorto,
+          distritoId: values.distritoId ?? current.distritoId,
+          direccion: values.direccion?.trim() ?? current.direccion,
+          latitud: values.latitud ?? current.latitud,
+          lonitud: values.longitud ?? current.longitud,
+          activo: values.activo ?? current.activo,
+        }),
+      );
+    },
+    remove: async (key: number): Promise<void> => {
+      await firstValueFrom(this.almacenService.delete(Number(key)));
+    },
+  });
+}


### PR DESCRIPTION
### Motivation
- Añadir el mantenimiento de almacenes en la UI `nest.core.view.security` para exponer las operaciones soportadas por el `AlmacenController` del backend y respetar el patrón de mantenimientos existentes (DX DataGrid + `CustomStore`).
- Reusar buenas prácticas del proyecto como manejo de errores con `NestUtils`, tipado de entidades/payloads y protección de rutas por claims.

### Description
- Se creó la entidad y payloads en `src/app/core/entities/almacen.entity.ts` con `AlmacenEntity`, `AlmacenCreatePayload` y `AlmacenUpdatePayload`.
- Se implementó `AlmacenService` en `src/app/core/services/logistica/almacenes/almacen.service.ts` consumiendo el endpoint `/logistica/Almacen` y las rutas `filter`, `/{id}`, `POST`, `PUT` y `DELETE`.
- Se añadió la página de mantenimiento `AlmacenesPageComponent` con `dx-data-grid` y `CustomStore` en `src/app/features/logistica/almacenes/` (`.ts`, `.html`, `.scss`) que realiza CRUD remoto y usa `NestUtils` para formatear errores.
- Se registró la ruta `logistica/almacen` en `src/app/app.routes.ts` y se protegió con `claimGuard('logistica-almacen')`; además se mapeó la diferencia de nombre entre `longitud` (UI) y `lonitud` (payload backend).

### Testing
- Se ejecutó `cd nest.core.view.security && npm run build` para validar la compilación del frontend y falló por limitación del entorno con el error `sh: 1: ng: not found` (Angular CLI no disponible), por lo que no se completó la build.
- No se ejecutaron otras pruebas automatizadas en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa5d08aba883338d80e5f706e683f4)