### PR TITLE
Agregar endpoints DataSource (filter/filter_activos) para Distritos y soporte en capas

### DIFF
--- a/nest.core.aplicacion.general/Distritos/Handlers/ObtenerDistritosPorFiltroActivosHandler.cs
+++ b/nest.core.aplicacion.general/Distritos/Handlers/ObtenerDistritosPorFiltroActivosHandler.cs
@@ -1,0 +1,32 @@
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.general.Distritos.Queries;
+using nest.core.dominio.General.DistritoEntities;
+
+namespace nest.core.aplicacion.general.Distritos.Handlers;
+
+public class ObtenerDistritosPorFiltroActivosHandler : IRequestHandler<ObtenerDistritosPorFiltroActivosQuery, LoadResult>
+{
+    private readonly IDistritoRepository repository;
+    private readonly ILogger<ObtenerDistritosPorFiltroActivosHandler> logger;
+
+    public ObtenerDistritosPorFiltroActivosHandler(IDistritoRepository repository, ILogger<ObtenerDistritosPorFiltroActivosHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerDistritosPorFiltroActivosQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerFilterActivos(request.options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los distritos activos por filtro");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.general/Distritos/Handlers/ObtenerDistritosPorFiltroHandler.cs
+++ b/nest.core.aplicacion.general/Distritos/Handlers/ObtenerDistritosPorFiltroHandler.cs
@@ -1,0 +1,32 @@
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.general.Distritos.Queries;
+using nest.core.dominio.General.DistritoEntities;
+
+namespace nest.core.aplicacion.general.Distritos.Handlers;
+
+public class ObtenerDistritosPorFiltroHandler : IRequestHandler<ObtenerDistritosPorFiltroQuery, LoadResult>
+{
+    private readonly IDistritoRepository repository;
+    private readonly ILogger<ObtenerDistritosPorFiltroHandler> logger;
+
+    public ObtenerDistritosPorFiltroHandler(IDistritoRepository repository, ILogger<ObtenerDistritosPorFiltroHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerDistritosPorFiltroQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerFilter(request.options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los distritos por filtro");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.general/Distritos/Queries/ObtenerDistritosPorFiltroActivosQuery.cs
+++ b/nest.core.aplicacion.general/Distritos/Queries/ObtenerDistritosPorFiltroActivosQuery.cs
@@ -1,0 +1,9 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.general.Distritos.Queries;
+
+public record ObtenerDistritosPorFiltroActivosQuery(
+    DataSourceLoadOptionsBase options)
+    : IRequest<LoadResult>;

--- a/nest.core.aplicacion.general/Distritos/Queries/ObtenerDistritosPorFiltroQuery.cs
+++ b/nest.core.aplicacion.general/Distritos/Queries/ObtenerDistritosPorFiltroQuery.cs
@@ -1,0 +1,9 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.general.Distritos.Queries;
+
+public record ObtenerDistritosPorFiltroQuery(
+    DataSourceLoadOptionsBase options)
+    : IRequest<LoadResult>;

--- a/nest.core.dominio/General/DistritoEntities/IDistritoRepository.cs
+++ b/nest.core.dominio/General/DistritoEntities/IDistritoRepository.cs
@@ -1,9 +1,14 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+
 namespace nest.core.dominio.General.DistritoEntities
 {
     public interface IDistritoRepository
     {
         Task<Distrito> ObtenerPorId(int id);
         Task<List<Distrito>> ObtenerTodos();
+        Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
+        Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
         Task<Distrito> Agregar(Distrito entry);
         Task<Distrito> Modificar(Distrito entry);
         Task Eliminar(int id);

--- a/nest.core.general/Controllers/DistritoController.cs
+++ b/nest.core.general/Controllers/DistritoController.cs
@@ -1,3 +1,5 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,7 +11,7 @@ using nest.core.dominio.General.DistritoEntities;
 namespace nest.core.general.Controllers
 {
     /// <summary>
-    /// Controlador para la gestión de Distritos
+    /// Controlador para la gestiÃ³n de Distritos
     /// </summary>
     [Authorize]
     [ApiController]
@@ -37,6 +39,27 @@ namespace nest.core.general.Controllers
             var entidad = await sender.Send(command);
             return Ok(entidad);
         }
+
+        [HttpPost("filter")]
+        [ProducesResponseType(typeof(LoadResult), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
+        public async Task<ActionResult<LoadResult>> ObtenerPorFiltro([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+        {
+            var data = await sender.Send(new ObtenerDistritosPorFiltroQuery(options), ct);
+            return Ok(data);
+        }
+
+        [HttpPost("filter_activos")]
+        [ProducesResponseType(typeof(LoadResult), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        [ProducesResponseType(401)]
+        public async Task<ActionResult<LoadResult>> ObtenerPorFiltroActivos([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+        {
+            var data = await sender.Send(new ObtenerDistritosPorFiltroActivosQuery(options), ct);
+            return Ok(data);
+        }
+
         [HttpPost]
         [ProducesResponseType(typeof(Distrito), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]

--- a/nest.core.infraestructura.general/DistritoRepository.cs
+++ b/nest.core.infraestructura.general/DistritoRepository.cs
@@ -1,8 +1,11 @@
 using AutoMapper;
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using nest.core.dominio.Cache;
 using nest.core.dominio.General.DistritoEntities;
 using nest.core.infraestructura.db.Cache;
 using nest.core.infraestructura.db.DbContext;
+using System.Linq;
 
 namespace nest.core.infraestructura.general
 {
@@ -11,6 +14,8 @@ namespace nest.core.infraestructura.general
         public DistritoRepository(NestDbContext context, IMapper mapper, ICacheRepository cache) : base(context, mapper, cache) { }
         public async Task<Distrito> ObtenerPorId(int id) => await GetByIdAsync(id);
         public async Task<List<Distrito>> ObtenerTodos() => await GetAllAsync();
+        public async Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoader.LoadAsync(Query(), options, cancellationToken);
+        public async Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoader.LoadAsync(Query(), options, cancellationToken);
         public async Task<Distrito> Agregar(Distrito dto) => await AddAsync(dto);
         public async Task<Distrito> Modificar(Distrito dto) => await UpdateAsync(dto);
         public async Task Eliminar(int id) => await DeleteAsync(id);


### PR DESCRIPTION
### Motivation
- Añadir soporte para consultas tipo DataSource (paginado/filtrado/orden) en la entidad `Distrito` replicando el patrón existente en `FormularioController` para que la UI pueda solicitar listados filtrados.

### Description
- Se añadieron en `DistritoController` los endpoints `POST /Distrito/filter` y `POST /Distrito/filter_activos` que reciben `DataSourceLoadOptionsBase` y devuelven `LoadResult` vía `ISender` (MediatR). 
- Se crearon las queries `ObtenerDistritosPorFiltroQuery` y `ObtenerDistritosPorFiltroActivosQuery` y sus handlers `ObtenerDistritosPorFiltroHandler` y `ObtenerDistritosPorFiltroActivosHandler`, que delegan al repositorio e incluyen logging de errores.
- Se extendió `IDistritoRepository` para exponer `ObtenerFilter(...)` y `ObtenerFilterActivos(...)` y se implementaron en `DistritoRepository` usando `DataSourceLoader.LoadAsync(...)` para aprovechar la carga/filtrado centralizado.
- `filter_activos` actualmente utiliza la misma consulta base que `filter` porque la entidad `Distrito` no tiene un campo de estado/activo para filtrar explícitamente en esta versión.

### Testing
- Se intentó compilar el proyecto con `dotnet build nest.core.general/nest.core.general.csproj`, pero la ejecución falló en el entorno porque `dotnet` no está disponible (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9c460ef88333bc25babc1b771ba5)