### PR TITLE
feat(view.security): agregar selector de distritos en AlmacenesPageComponent

### DIFF
--- a/nest.core.view.security/src/app/core/entities/distrito.entity.ts
+++ b/nest.core.view.security/src/app/core/entities/distrito.entity.ts
@@ -1,0 +1,6 @@
+export interface DistritoEntity {
+  id: number;
+  nombre: string;
+  provinciaId: number;
+}
+

--- a/nest.core.view.security/src/app/core/services/general/distritos/distrito.service.ts
+++ b/nest.core.view.security/src/app/core/services/general/distritos/distrito.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LoadOptions, LoadResult } from 'devextreme/common/data';
+
+import { DistritoEntity } from '@app/core/entities/distrito.entity';
+import { environment } from '@environment/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DistritoService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly endpoint = `${environment.apiBaseUrl}/general/Distrito`;
+
+  getByFilterActivos(loadOptions: LoadOptions): Observable<LoadResult<DistritoEntity[]>> {
+    return this.httpClient.post<LoadResult<DistritoEntity[]>>(`${this.endpoint}/filter_activos`, loadOptions);
+  }
+}

--- a/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.html
+++ b/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.html
@@ -25,7 +25,9 @@
       <dxi-column dataField="empresaId" caption="Empresa Id" [allowEditing]="false" [visible]="false" [calculateCellValue]="($event) => this.sessionService.currentUser()?.empresaId"></dxi-column>
       <dxi-column dataField="nombre" caption="Nombre" [validationRules]="[{ type: 'required' }]" ></dxi-column>
       <dxi-column dataField="nombreCorto" caption="Nombre Corto" [validationRules]="[{ type: 'required' }]" ></dxi-column>
-      <dxi-column dataField="distritoId" caption="Distrito Id" dataType="number" [validationRules]="[{ type: 'required' }]" ></dxi-column>
+      <dxi-column dataField="distritoId" caption="Distrito" dataType="number" [validationRules]="[{ type: 'required' }]" >
+        <dxo-lookup [dataSource]="distritosDataSource" valueExpr="id" displayExpr="nombre"></dxo-lookup>
+      </dxi-column>
       <dxi-column dataField="direccion" caption="Dirección" [validationRules]="[{ type: 'required' }]" ></dxi-column>
       <dxi-column dataField="latitud" caption="Latitud" dataType="number"></dxi-column>
       <dxi-column dataField="lonitud" caption="Longitud" dataType="number"></dxi-column>

--- a/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.ts
+++ b/nest.core.view.security/src/app/features/logistica/almacenes/pages/almacenes-page.component.ts
@@ -5,6 +5,8 @@ import { DxDataGridModule } from 'devextreme-angular';
 import { LoadOptions, LoadResult } from 'devextreme/common/data';
 
 import { AlmacenCreatePayload, AlmacenEntity, AlmacenUpdatePayload } from '@app/core/entities/almacen.entity';
+import { DistritoEntity } from '@app/core/entities/distrito.entity';
+import { DistritoService } from '@app/core/services/general/distritos/distrito.service';
 import { AlmacenService } from '@app/core/services/logistica/almacenes/almacen.service';
 import { NestUtils } from '@app/core/services/util/nestUtils';
 import { UserSessionService } from '@app/core/services/ui/user-session.service';
@@ -18,8 +20,21 @@ import { UserSessionService } from '@app/core/services/ui/user-session.service';
 })
 export class AlmacenesPageComponent {
   private readonly almacenService = inject(AlmacenService);
+  private readonly distritoService = inject(DistritoService);
   protected readonly sessionService = inject(UserSessionService);
 
+
+  protected readonly distritosDataSource = new CustomStore<DistritoEntity, number>({
+    key: 'id',
+    useDefaultSearch: true,
+    load: async (options: LoadOptions): Promise<LoadResult<DistritoEntity[]>> => {
+      try {
+        return await firstValueFrom(this.distritoService.getByFilterActivos(options));
+      } catch (e: any) {
+        throw NestUtils.formatValidationErrors(e);
+      }
+    },
+  });
   protected readonly almacenesDataSource = new CustomStore<AlmacenEntity, number>({
     key: 'id',
     useDefaultSearch: true,


### PR DESCRIPTION
### Motivation
- Permitir seleccionar un distrito por nombre en el formulario de mantenimiento de almacenes en lugar de introducir manualmente el Id, reutilizando el endpoint de `DistritoController` del módulo `nest.core.general`.

### Description
- Se agregó la interfaz `DistritoEntity` en `nest.core.view.security/src/app/core/entities/distrito.entity.ts` para tipar los distritos.
- Se creó `DistritoService` en `nest.core.view.security/src/app/core/services/general/distritos/distrito.service.ts` que consume `POST /general/Distrito/filter_activos` como fuente de datos.
- En `AlmacenesPageComponent` se inyectó `DistritoService`, se añadió un `CustomStore` `distritosDataSource` y se importó la nueva entidad para cargar distritos dinámicamente.
- En la vista se cambió la columna `distritoId` por un `dxo-lookup` que usa `distritosDataSource` con `valueExpr="id"` y `displayExpr="nombre"` para mostrar un selector por nombre.

### Testing
- Se intentó compilar el frontend ejecutando `cd nest.core.view.security && npm run build -- --configuration development`, pero la compilación falló por limitación del entorno con el error `ng: not found` (Angular CLI no disponible), por lo que no se pudo validar la build automáticamente.
- No se ejecutaron suites de pruebas automatizadas adicionales dentro de este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9e3a2cf083339bfb31574b537392)