### PR TITLE
Crear API REST nest.core.iclock

### DIFF
--- a/nest.core.iclock/Controllers/IclockController.cs
+++ b/nest.core.iclock/Controllers/IclockController.cs
@@ -1,0 +1,164 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.rrhh.RegistroAsistencias.Commands;
+using nest.core.dominio;
+using nest.core.iclock.Models;
+using System.Globalization;
+
+namespace nest.core.iclock.Controllers
+{
+    /// <summary>
+    /// Controlador compatible con terminales biométricos que publican marcaciones mediante el protocolo iClock.
+    /// </summary>
+    [AllowAnonymous]
+    [ApiController]
+    [Route("iclock")]
+    public class IclockController : ControllerBase
+    {
+        private readonly ISender sender;
+        private readonly ILogger<IclockController> logger;
+        private readonly int empresaId;
+
+        public IclockController(ISender sender, ILogger<IclockController> logger, IConfiguration configuration)
+        {
+            this.sender = sender;
+            this.logger = logger;
+            empresaId = configuration.GetValue<int?>("Iclock:EmpresaId") ?? 1;
+        }
+
+        /// <summary>
+        /// Endpoint de alta/keep-alive del dispositivo iClock.
+        /// </summary>
+        [HttpGet("cdata")]
+        [ProducesResponseType(typeof(string), 200)]
+        public ActionResult<string> Handshake([FromQuery] string SN)
+        {
+            logger.LogInformation("Handshake iClock recibido desde {SerialNumber}", SN);
+            return Content("OK", "text/plain");
+        }
+
+        /// <summary>
+        /// Recibe una o varias marcaciones de asistencia enviadas por el reloj biométrico.
+        /// </summary>
+        [HttpPost("cdata")]
+        [Consumes("text/plain", "application/octet-stream", "application/x-www-form-urlencoded")]
+        [ProducesResponseType(typeof(string), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<string>> RecibirMarcaciones([FromQuery] string SN, CancellationToken ct)
+        {
+            using var reader = new StreamReader(Request.Body);
+            var payload = await reader.ReadToEndAsync(ct);
+            var resultado = await ProcesarMarcaciones(payload, SN, ct);
+
+            if (resultado.Errores.Count > 0)
+                logger.LogWarning("Marcaciones iClock procesadas con observaciones para {SerialNumber}: {Errores}", SN, string.Join(" | ", resultado.Errores));
+
+            return Content("OK", "text/plain");
+        }
+
+        /// <summary>
+        /// Permite validar manualmente el procesamiento de marcaciones desde clientes REST.
+        /// </summary>
+        [HttpPost("attendance")]
+        [ProducesResponseType(typeof(IclockResponse), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<IclockResponse>> RecibirMarcacionesRest([FromBody] string payload, [FromQuery] string SN, CancellationToken ct)
+        {
+            var resultado = await ProcesarMarcaciones(payload, SN, ct);
+            return Ok(resultado);
+        }
+
+        /// <summary>
+        /// Endpoint consultado por dispositivos iClock para obtener comandos pendientes.
+        /// </summary>
+        [HttpGet("getrequest")]
+        [ProducesResponseType(typeof(string), 200)]
+        public ActionResult<string> ObtenerComandos([FromQuery] string SN)
+        {
+            logger.LogDebug("Consulta de comandos iClock desde {SerialNumber}", SN);
+            return Content("OK", "text/plain");
+        }
+
+        /// <summary>
+        /// Confirma la recepción de respuestas a comandos ejecutados por el dispositivo.
+        /// </summary>
+        [HttpPost("devicecmd")]
+        [ProducesResponseType(typeof(string), 200)]
+        public async Task<ActionResult<string>> ConfirmarComando([FromQuery] string SN, CancellationToken ct)
+        {
+            using var reader = new StreamReader(Request.Body);
+            var payload = await reader.ReadToEndAsync(ct);
+            logger.LogInformation("Respuesta de comando iClock recibida desde {SerialNumber}: {Payload}", SN, payload);
+            return Content("OK", "text/plain");
+        }
+
+        private async Task<IclockResponse> ProcesarMarcaciones(string payload, string serialNumber, CancellationToken ct)
+        {
+            var procesados = 0;
+            var omitidos = 0;
+            var errores = new List<string>();
+
+            foreach (var line in ObtenerLineas(payload))
+            {
+                if (!TryParseMarcacion(line, serialNumber, out var record, out var error))
+                {
+                    omitidos++;
+                    errores.Add(error);
+                    continue;
+                }
+
+                if (!int.TryParse(record.Pin, out var personalId))
+                {
+                    omitidos++;
+                    errores.Add($"El PIN '{record.Pin}' no corresponde a un PersonalId numérico.");
+                    continue;
+                }
+
+                await sender.Send(new RegistroAsistenciaCrearCommand(empresaId, personalId, record.Fecha, null, null), ct);
+                procesados++;
+            }
+
+            return new IclockResponse(serialNumber, procesados, omitidos, errores);
+        }
+
+        private static IEnumerable<string> ObtenerLineas(string payload)
+        {
+            return (payload ?? string.Empty)
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x));
+        }
+
+        private static bool TryParseMarcacion(string line, string serialNumber, out IclockAttendanceRecord record, out string error)
+        {
+            record = null;
+            error = null;
+
+            var parts = line.Split(new[] { '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2)
+            {
+                error = $"La línea '{line}' no tiene el formato esperado.";
+                return false;
+            }
+
+            var fechaTexto = parts.Length > 2 ? $"{parts[1]} {parts[2]}" : parts[1];
+            if (!DateTime.TryParseExact(fechaTexto, new[] { "yyyy-MM-dd HH:mm:ss", "yyyy/MM/dd HH:mm:ss", "yyyy-MM-ddTHH:mm:ss" }, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var fecha))
+            {
+                error = $"La fecha '{fechaTexto}' de la línea '{line}' no es válida.";
+                return false;
+            }
+
+            var offset = parts.Length > 2 ? 3 : 2;
+            record = new IclockAttendanceRecord(
+                parts[0],
+                fecha,
+                parts.ElementAtOrDefault(offset) ?? string.Empty,
+                parts.ElementAtOrDefault(offset + 1) ?? string.Empty,
+                parts.ElementAtOrDefault(offset + 2) ?? string.Empty,
+                parts.ElementAtOrDefault(offset + 3) ?? string.Empty,
+                serialNumber);
+            return true;
+        }
+    }
+}

--- a/nest.core.iclock/Dockerfile
+++ b/nest.core.iclock/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["nest.core.iclock/nest.core.iclock.csproj", "nest.core.iclock/"]
+RUN dotnet restore "nest.core.iclock/nest.core.iclock.csproj"
+COPY . .
+WORKDIR "/src/nest.core.iclock"
+RUN dotnet build "nest.core.iclock.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "nest.core.iclock.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "nest.core.iclock.dll"]

--- a/nest.core.iclock/Extensions/ConfigureServices.cs
+++ b/nest.core.iclock/Extensions/ConfigureServices.cs
@@ -1,0 +1,50 @@
+using FluentValidation;
+using MediatR;
+using nest.core.aplicacion.rrhh;
+using nest.core.aplicacion.rrhh.RegistroAsistenciaOrdenTrabajos.Behaviors;
+using nest.core.aplicacion.utils.Behaviors;
+using nest.core.dominio.Cache;
+using nest.core.infraestructura.db.Cache;
+
+namespace nest.core.iclock.Extensions
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureAplication(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.ConfigureValidation();
+            services.ConfigureCache(configuration);
+            services.ConfigureInfraestructura(configuration);
+            return services;
+        }
+
+        private static void ConfigureCache(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            bool useRedis = configuration.GetValue<bool>($"RedisConfig:Enabled");
+            if (useRedis)
+            {
+                services.AddStackExchangeRedisCache(options =>
+                {
+                    options.Configuration = configuration.GetValue<string>($"RedisConfig:ConnectionString");
+                    options.InstanceName = configuration.GetValue<string>($"RedisConfig:InstanceName");
+                });
+                services.AddScoped<ICacheRepository, RedisCacheRepository>();
+            }
+            else
+            {
+                services.AddMemoryCache();
+                services.AddScoped<ICacheRepository, MemoryCacheRepository>();
+            }
+        }
+
+        private static void ConfigureValidation(this IServiceCollection services)
+        {
+            services.AddValidatorsFromAssembly(typeof(RegistroAsistenciaOrdenTrabajoCrearUsuarioActualValidator).Assembly);
+            services.AddMediatR(cnf =>
+            {
+                cnf.RegisterServicesFromAssemblyContaining(typeof(RegistroAsistenciaOrdenTrabajoCrearUsuarioActualValidator));
+                cnf.AddOpenBehavior(typeof(ValidationBehavior<,>));
+            });
+        }
+    }
+}

--- a/nest.core.iclock/Models/IclockAttendanceRecord.cs
+++ b/nest.core.iclock/Models/IclockAttendanceRecord.cs
@@ -1,0 +1,11 @@
+namespace nest.core.iclock.Models
+{
+    public record IclockAttendanceRecord(
+        string Pin,
+        DateTime Fecha,
+        string Estado,
+        string Verificacion,
+        string WorkCode,
+        string Reservado,
+        string SerialNumber);
+}

--- a/nest.core.iclock/Models/IclockResponse.cs
+++ b/nest.core.iclock/Models/IclockResponse.cs
@@ -1,0 +1,4 @@
+namespace nest.core.iclock.Models
+{
+    public record IclockResponse(string SerialNumber, int Procesados, int Omitidos, IReadOnlyList<string> Errores);
+}

--- a/nest.core.iclock/Program.cs
+++ b/nest.core.iclock/Program.cs
@@ -1,0 +1,107 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using nest.core.aplication.auth;
+using nest.core.iclock.Extensions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateBuilder(args);
+Console.WriteLine("Iniciando aplicación Iclock...");
+if (Environment.GetEnvironmentVariable("IS_LAMBDA") != null)
+    builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+
+builder.Configuration.AddJsonFile("appsettings.json", optional: true)
+                     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+                     .AddUserSecrets<Program>()
+                     .AddEnvironmentVariables();
+DbContextSelector.SelectProvider(builder, true);
+builder.Services.ConfigureAplication(builder.Configuration);
+builder.Services.AddHealthChecks().AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("CorsPolicy", builder =>
+    {
+        builder.AllowAnyOrigin()
+               .AllowAnyMethod()
+               .AllowAnyHeader();
+    });
+});
+
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+    });
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    string proyecto = Assembly.GetExecutingAssembly().GetName().Name.Split('.')[2];
+    proyecto = char.ToUpper(proyecto[0]) + proyecto.Substring(1).ToLower();
+    string apiName = $"{proyecto} Api";
+    c.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = apiName,
+        Version = $"v{Assembly.GetExecutingAssembly().GetName().Version}",
+        Description = $"La {apiName} permite recibir marcaciones de relojes biométricos compatibles con iClock.",
+        Contact = new OpenApiContact { Email = "gabogth@gmail.com", Name = "Gabriel Rodriguez", Url = new Uri("https://es.stackoverflow.com/users/30423") }
+    });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "Ingrese el token JWT en este formato: Bearer {token}",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer",
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement(){{
+        new OpenApiSecurityScheme {
+            Reference = new OpenApiReference {
+                Type = ReferenceType.SecurityScheme,
+                Id = "Bearer"
+            }
+        },
+        new string[] {} }
+    });
+    c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"));
+});
+builder.Services.AddAuthentication(option =>
+{
+    option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    option.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(option =>
+{
+    option.SaveToken = true;
+    option.TokenValidationParameters = new TokenValidationParameters
+    {
+        SaveSigninToken = true,
+        ValidateIssuer = true,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Issuer"],
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
+
+var app = builder.Build();
+if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("BASE_URL")))
+    app.UsePathBase(Environment.GetEnvironmentVariable("BASE_URL"));
+app.UseSwagger();
+app.UseSwaggerUI();
+app.UseHttpsRedirection();
+app.UseCors("CorsPolicy");
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = check => check.Tags.Contains("live") });
+app.UseMiddleware<ErrorHandlingMiddleware>();
+app.MapControllers();
+app.Run();

--- a/nest.core.iclock/Properties/launchSettings.json
+++ b/nest.core.iclock/Properties/launchSettings.json
@@ -1,0 +1,26 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ENGINE": "SqlServer"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:8283"
+    },
+    "https": {
+      "commandName": "Project",
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ENGINE": "Npgsql"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:8383;"
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json"
+}

--- a/nest.core.iclock/appsettings.Development.json
+++ b/nest.core.iclock/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Iclock": {
+    "EmpresaId": 1
+  }
+}

--- a/nest.core.iclock/appsettings.json
+++ b/nest.core.iclock/appsettings.json
@@ -1,0 +1,27 @@
+{
+  "Connections": {
+    "SqlServer": "Server=localhost,1433;Database=nest;User Id=sa;Password=4N&XY&d_0y6+;TrustServerCertificate=true;MultipleActiveResultSets=true;Application Name=Nest;",
+    "Npgsql": "Host=localhost;Port=5431;Database=nest;Username=postgres;Password=4N&XY&d_0y6+;Application Name=Nest;",
+    "MySql": "server=localhost;port=3305;database=nest;uid=root;pwd=4N&XY&d_0y6+;Application Name=Nest;"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Jwt": {
+    "Issuer": "https://empresa.com",
+    "Audience": "https://empresa.com",
+    "Key": "ckO9z0o8ZppcIbrOsT8Nj58uKgZkJwOoNwNVLpJVPz0="
+  },
+  "RedisConfig": {
+    "Enabled": false,
+    "ConnectionString": "localhost:6379",
+    "InstanceName": "Nest_"
+  },
+  "AllowedHosts": "*",
+  "Iclock": {
+    "EmpresaId": 1
+  }
+}

--- a/nest.core.iclock/lambda.Dockerfile
+++ b/nest.core.iclock/lambda.Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+ARG BUILD_CONFIGURATION=Release
+
+WORKDIR /src
+COPY ["nest.core.iclock/nest.core.iclock.csproj", "nest.core.iclock/"]
+RUN dotnet restore "nest.core.iclock/nest.core.iclock.csproj"
+COPY . .
+WORKDIR /src/nest.core.iclock
+RUN dotnet publish "nest.core.iclock.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:PublishReadyToRun=true
+
+FROM public.ecr.aws/lambda/dotnet:9 AS final
+WORKDIR /var/task
+COPY --from=build /app/publish ./
+
+CMD ["nest.core.iclock"]

--- a/nest.core.iclock/nest.core.iclock.csproj
+++ b/nest.core.iclock/nest.core.iclock.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>1591</NoWarn>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <UserSecretsId>0f91d37d-0f89-4f33-a53b-7d5f2c7b1bb1</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\.dockerignore" Link=".dockerignore">
+      <DependentUpon>$(DockerDefaultDockerfile)</DependentUpon>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.9.0" />
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplicacion.rrhh\nest.core.aplicacion.rrhh.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Motivation
- Proveer un endpoint REST compatible con dispositivos iClock para recibir y procesar marcaciones de asistencia reutilizando la lógica existente de RRHH.
- Mantener el estándar de proyecto (inicio, Swagger, JWT, CORS, health checks, cache e infraestructura compartida) para nuevos microservicios API.

### Description
- Agrega el nuevo proyecto `nest.core.iclock` con `nest.core.iclock.csproj` y referencias a `nest.core.aplicacion.rrhh` y `nest.core.infraestructura.db` para reutilizar handlers y repositorios de RRHH.
- Implementa `Program.cs` con configuración estándar (appsettings, selección de provider, Swagger, autenticación JWT, CORS, health checks y middleware de errores) y `Extensions/ConfigureServices.cs` para validación, MediatR y cache (Redis/memoria).
- Añade `IclockController` con endpoints `GET /iclock/cdata` (handshake), `POST /iclock/cdata` (recepción de marcaciones), `POST /iclock/attendance` (test REST), `GET /iclock/getrequest` y `POST /iclock/devicecmd`; el procesamiento parsea líneas de texto, valida PIN a `PersonalId` y envía `RegistroAsistenciaCrearCommand`.
- Incluye modelos (`IclockAttendanceRecord`, `IclockResponse`), archivos `appsettings.json`/`appsettings.Development.json` con `Iclock:EmpresaId`, `Dockerfile`, `lambda.Dockerfile` y `Properties/launchSettings.json`.

### Testing
- Intenté ejecutar `dotnet build nest.core.iclock/nest.core.iclock.csproj --no-restore` pero falló porque el contenedor no tiene `dotnet` instalado, por lo que no se ejecutó la compilación automatizada.
- Se verificó el estado del repositorio (`git status`) después de los cambios y los archivos del proyecto se añadieron correctamente al árbol de trabajo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a542ce5653083338076887bb97a1356)