### PR TITLE
Add TerminalBiometrico CRUD layers

### DIFF
--- a/nest.core.aplicacion.rrhh/ConfigureServices.cs
+++ b/nest.core.aplicacion.rrhh/ConfigureServices.cs
@@ -16,6 +16,7 @@ using nest.core.dominio.RRHH.RegistroAsistenciaAdjuntoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaOrdenTrabajoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaPoliticaEntities;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
 using nest.core.dominio.Security.Tenant;
 using nest.core.dominio.Transaccional;
 using nest.core.infraestructura.db.Transaccional;
@@ -44,6 +45,7 @@ namespace nest.core.aplicacion.rrhh
             services.AddTransient<IRegistroAsistenciaRepository, RegistroAsistenciaRepository>();
             services.AddTransient<IRegistroAsistenciaOrdenTrabajoRepository, RegistroAsistenciaOrdenTrabajoRepository>();
             services.AddTransient<IRegistroAsistenciaPoliticaRepository, RegistroAsistenciaPoliticaRepository>();
+            services.AddTransient<ITerminalBiometricoRepository, TerminalBiometricoRepository>();
             services.AddTransient<IOrdenTrabajoCabeceraRepository, OrdenTrabajoCabeceraRepository>();
             services.AddTransient<IRegistroAsistencia_OrdenTrabajoRepository, RegistroAsistencia_OrdenTrabajoRepository>();
             services.AddTransient<IOrdenTrabajoHorarioRepository, OrdenTrabajoHorarioRepository>();

--- a/nest.core.aplicacion.rrhh/Mapper/AutoMapperProfiles.cs
+++ b/nest.core.aplicacion.rrhh/Mapper/AutoMapperProfiles.cs
@@ -11,6 +11,7 @@ using nest.core.aplicacion.rrhh.RegistroAsistenciaAdjuntos.Commands;
 using nest.core.aplicacion.rrhh.RegistroAsistenciaOrdenTrabajos.Commands;
 using nest.core.aplicacion.rrhh.RegistroAsistenciaPoliticas.Commands;
 using nest.core.aplicacion.rrhh.RegistroAsistencias.Commands;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
 using nest.core.dominio.RRHH.CargoEntities;
 using nest.core.dominio.RRHH.FrecuenciaPagoEntities;
 using nest.core.dominio.RRHH.GrupoTrabajoEntities;
@@ -24,6 +25,7 @@ using nest.core.dominio.RRHH.RegistroAsistenciaAdjuntoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaOrdenTrabajoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaPoliticaEntities;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
 
 namespace nest.core.aplicacion.rrhh.Mapper
 {
@@ -60,6 +62,8 @@ namespace nest.core.aplicacion.rrhh.Mapper
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.RegistroAsistenciaId));
             CreateMap<RegistroAsistenciaAdjuntoModificarCommand, RegistroAsistenciaAdjunto>()
                 .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.RegistroAsistenciaId));
+            CreateMap<TerminalBiometricoCrearCommand, TerminalBiometrico>();
+            CreateMap<TerminalBiometricoModificarCommand, TerminalBiometrico>();
             CreateMap<HorarioCabecera, HorarioCabecera>();
         }
 
@@ -104,6 +108,7 @@ namespace nest.core.aplicacion.rrhh.Mapper
                 .ForMember(dest => dest.RegistroAsistencia, opt => opt.Ignore())
                 .ForMember(dest => dest.OrdenTrabajoCabecera, opt => opt.Ignore());
             CreateMap<RegistroAsistenciaPolitica, RegistroAsistenciaPolitica>();
+            CreateMap<TerminalBiometrico, TerminalBiometrico>();
         }
     }
 }

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoCrearValidator.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoCrearValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Behaviors;
+
+public class TerminalBiometricoCrearValidator : AbstractValidator<TerminalBiometricoCrearCommand>
+{
+    public TerminalBiometricoCrearValidator()
+    {
+        Include(new TerminalBiometricoGenericValidator<TerminalBiometricoCrearCommand>());
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoEliminarValidator.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoEliminarValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Behaviors;
+
+public class TerminalBiometricoEliminarValidator : AbstractValidator<TerminalBiometricoEliminarCommand>
+{
+    public TerminalBiometricoEliminarValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0).WithMessage("El identificador es obligatorio.");
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoGenericValidator.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoGenericValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Behaviors
+{
+    public class TerminalBiometricoGenericValidator<TCommand> : AbstractValidator<TCommand>
+        where TCommand : ITerminalBiometricoGenericCommand
+    {
+        public TerminalBiometricoGenericValidator()
+        {
+            RuleFor(x => x.EmpresaId)
+                .GreaterThan(0).WithMessage("La empresa es obligatoria.");
+
+            RuleFor(x => x.Nombre)
+                .NotEmpty().WithMessage("El nombre es obligatorio.")
+                .MaximumLength(200).WithMessage("El nombre no puede exceder 200 caracteres.");
+
+            RuleFor(x => x.SN)
+                .NotEmpty().WithMessage("El número de serie es obligatorio.")
+                .MaximumLength(200).WithMessage("El número de serie no puede exceder 200 caracteres.");
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoModificarValidator.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Behaviors/TerminalBiometricoModificarValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Behaviors;
+
+public class TerminalBiometricoModificarValidator : AbstractValidator<TerminalBiometricoModificarCommand>
+{
+    public TerminalBiometricoModificarValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0).WithMessage("El identificador es obligatorio.");
+
+        Include(new TerminalBiometricoGenericValidator<TerminalBiometricoModificarCommand>());
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/ITerminalBiometricoGenericCommand.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/ITerminalBiometricoGenericCommand.cs
@@ -1,0 +1,11 @@
+using nest.core.aplicacion.utils.Commands;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Commands
+{
+    public interface ITerminalBiometricoGenericCommand : ICommandBase
+    {
+        int EmpresaId { get; }
+        string Nombre { get; }
+        string SN { get; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/TerminalBiometricoCrearCommand.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/TerminalBiometricoCrearCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+public record TerminalBiometricoCrearCommand(
+    int EmpresaId,
+    string Nombre,
+    string SN
+) : IRequest<TerminalBiometrico>, ITerminalBiometricoGenericCommand;

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/TerminalBiometricoEliminarCommand.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/TerminalBiometricoEliminarCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.aplicacion.utils.Commands;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+public record TerminalBiometricoEliminarCommand(int Id) : IRequest<Unit>, ICommandBase;

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/TerminalBiometricoModificarCommand.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Commands/TerminalBiometricoModificarCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+
+public record TerminalBiometricoModificarCommand(
+    int Id,
+    int EmpresaId,
+    string Nombre,
+    string SN
+) : IRequest<TerminalBiometrico>, ITerminalBiometricoGenericCommand;

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricoPorIdHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricoPorIdHandler.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class ObtenerTerminalBiometricoPorIdHandler : IRequestHandler<ObtenerTerminalBiometricoPorIdQuery, TerminalBiometrico>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly ILogger<ObtenerTerminalBiometricoPorIdHandler> logger;
+
+    public ObtenerTerminalBiometricoPorIdHandler(ITerminalBiometricoRepository repository, ILogger<ObtenerTerminalBiometricoPorIdHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<TerminalBiometrico> Handle(ObtenerTerminalBiometricoPorIdQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerPorId(request.Id);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener el terminal biométrico {Id}", request.Id);
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricosHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricosHandler.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class ObtenerTerminalBiometricosHandler : IRequestHandler<ObtenerTerminalBiometricosQuery, List<TerminalBiometrico>>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly ILogger<ObtenerTerminalBiometricosHandler> logger;
+
+    public ObtenerTerminalBiometricosHandler(ITerminalBiometricoRepository repository, ILogger<ObtenerTerminalBiometricosHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<List<TerminalBiometrico>> Handle(ObtenerTerminalBiometricosQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerTodos();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los terminales biométricos");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/TerminalBiometricoCrearHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/TerminalBiometricoCrearHandler.cs
@@ -1,0 +1,35 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class TerminalBiometricoCrearHandler : IRequestHandler<TerminalBiometricoCrearCommand, TerminalBiometrico>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly IMapper mapper;
+    private readonly ILogger<TerminalBiometricoCrearHandler> logger;
+
+    public TerminalBiometricoCrearHandler(ITerminalBiometricoRepository repository, IMapper mapper, ILogger<TerminalBiometricoCrearHandler> logger)
+    {
+        this.repository = repository;
+        this.mapper = mapper;
+        this.logger = logger;
+    }
+
+    public async Task<TerminalBiometrico> Handle(TerminalBiometricoCrearCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = mapper.Map<TerminalBiometrico>(request);
+            return await repository.Agregar(entity);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al crear el terminal biométrico {Nombre}", request.Nombre);
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/TerminalBiometricoEliminarHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/TerminalBiometricoEliminarHandler.cs
@@ -1,0 +1,32 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class TerminalBiometricoEliminarHandler : IRequestHandler<TerminalBiometricoEliminarCommand, Unit>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly ILogger<TerminalBiometricoEliminarHandler> logger;
+
+    public TerminalBiometricoEliminarHandler(ITerminalBiometricoRepository repository, ILogger<TerminalBiometricoEliminarHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<Unit> Handle(TerminalBiometricoEliminarCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await repository.Eliminar(request.Id);
+            return Unit.Value;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al eliminar el terminal biométrico {Id}", request.Id);
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/TerminalBiometricoModificarHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/TerminalBiometricoModificarHandler.cs
@@ -1,0 +1,35 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class TerminalBiometricoModificarHandler : IRequestHandler<TerminalBiometricoModificarCommand, TerminalBiometrico>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly IMapper mapper;
+    private readonly ILogger<TerminalBiometricoModificarHandler> logger;
+
+    public TerminalBiometricoModificarHandler(ITerminalBiometricoRepository repository, IMapper mapper, ILogger<TerminalBiometricoModificarHandler> logger)
+    {
+        this.repository = repository;
+        this.mapper = mapper;
+        this.logger = logger;
+    }
+
+    public async Task<TerminalBiometrico> Handle(TerminalBiometricoModificarCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var entity = mapper.Map<TerminalBiometrico>(request);
+            return await repository.Modificar(entity);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al modificar el terminal biométrico {Id}", request.Id);
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricoPorIdQuery.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricoPorIdQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+
+public record ObtenerTerminalBiometricoPorIdQuery(int Id) : IRequest<TerminalBiometrico>;

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricosQuery.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricosQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+
+public record ObtenerTerminalBiometricosQuery : IRequest<List<TerminalBiometrico>>;

--- a/nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs
+++ b/nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs
@@ -1,0 +1,11 @@
+namespace nest.core.dominio.RRHH.TerminalBiometricoEntities
+{
+    public interface ITerminalBiometricoRepository
+    {
+        Task<TerminalBiometrico> ObtenerPorId(int id);
+        Task<List<TerminalBiometrico>> ObtenerTodos();
+        Task<TerminalBiometrico> Agregar(TerminalBiometrico entry);
+        Task<TerminalBiometrico> Modificar(TerminalBiometrico entry);
+        Task Eliminar(int id);
+    }
+}

--- a/nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs
+++ b/nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs
@@ -1,0 +1,29 @@
+using AutoMapper;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.infraestructura.db.Utils;
+using nest.core.infrastructura.utils.Excepciones;
+
+namespace nest.core.infraestructura.rrhh;
+
+public class TerminalBiometricoRepository : CrudRepositoryBase<TerminalBiometrico, int>, ITerminalBiometricoRepository
+{
+    public TerminalBiometricoRepository(NestDbContext context, IMapper mapper) : base(context, mapper)
+    {
+    }
+
+    public async Task<TerminalBiometrico> ObtenerPorId(int id) =>
+        await GetByIdAsync(id) ?? throw new RegistroNoEncontradoException<TerminalBiometrico>(id.ToString());
+
+    public async Task<List<TerminalBiometrico>> ObtenerTodos() => await GetAllAsync();
+
+    public Task<TerminalBiometrico> Agregar(TerminalBiometrico entry) => AddAsync(entry);
+
+    public async Task<TerminalBiometrico> Modificar(TerminalBiometrico entry)
+    {
+        await UpdateAsync(entry);
+        return await ObtenerPorId(entry.Id);
+    }
+
+    public Task Eliminar(int id) => DeleteAsync(id);
+}

--- a/nest.core.rrhh/Controllers/TerminalBiometricoController.cs
+++ b/nest.core.rrhh/Controllers/TerminalBiometricoController.cs
@@ -1,0 +1,67 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Commands;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+using nest.core.dominio;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.rrhh.Controllers;
+
+[Authorize]
+[Route("[controller]")]
+[ApiController]
+public class TerminalBiometricoController : ControllerBase
+{
+    private readonly ISender sender;
+
+    public TerminalBiometricoController(ISender sender)
+    {
+        this.sender = sender;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(List<TerminalBiometrico>), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<List<TerminalBiometrico>>> ObtenerTodos(CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerTerminalBiometricosQuery(), ct);
+        return Ok(data);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(TerminalBiometrico), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<TerminalBiometrico>> ObtenerPorId(int id, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerTerminalBiometricoPorIdQuery(id), ct);
+        return Ok(data);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(TerminalBiometrico), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<TerminalBiometrico>> Agregar([FromBody] TerminalBiometricoCrearCommand command, CancellationToken ct)
+    {
+        var data = await sender.Send(command, ct);
+        return Ok(data);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(TerminalBiometrico), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult<TerminalBiometrico>> Modificar(int id, [FromBody] TerminalBiometricoModificarCommand command, CancellationToken ct)
+    {
+        var data = await sender.Send(command with { Id = id }, ct);
+        return Ok(data);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    public async Task<ActionResult> Eliminar(int id, CancellationToken ct)
+    {
+        await sender.Send(new TerminalBiometricoEliminarCommand(id), ct);
+        return Ok();
+    }
+}


### PR DESCRIPTION
### Motivation

- Añadir soporte completo CRUD para la entidad `TerminalBiometrico` en dominio, infraestructura, capa de aplicación y la API para poder gestionar terminales biométricos desde los endpoints existentes. 
- Mantener la consistencia con el patrón ya usado en otros módulos (repositorio, handlers, comandos, validadores y controlador). 
- Permitir mapeo automático entre comandos y la entidad mediante `AutoMapper` y registrar la dependencia en el contenedor de servicios.

### Description

- Se agregó el contrato de dominio `ITerminalBiometricoRepository` con operaciones CRUD para `TerminalBiometrico` en `nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs`.
- Se implementó `TerminalBiometricoRepository` sobre `CrudRepositoryBase` en `nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs` con `ObtenerPorId`, `ObtenerTodos`, `Agregar`, `Modificar` y `Eliminar` y manejo de `RegistroNoEncontradoException`.
- Se creó la capa de aplicación con comandos (`TerminalBiometricoCrearCommand`, `TerminalBiometricoModificarCommand`, `TerminalBiometricoEliminarCommand`), queries, handlers y validadores en `nest.core.aplicacion.rrhh/TerminalBiometricos/...` siguiendo la misma estructura que otros agregados del módulo RRHH.
- Se añadió el controlador `TerminalBiometricoController` con endpoints autorizados para listar, obtener por id, crear, modificar y eliminar en `nest.core.rrhh/Controllers/TerminalBiometricoController.cs`, y se registraron los mappings de `AutoMapper` y la inyección del repositorio (`ITerminalBiometricoRepository` → `TerminalBiometricoRepository`) en `ConfigureServices`.

### Testing

- Intenté compilar con `dotnet build nest.sln --no-restore`, pero la orden no pudo ejecutarse porque `dotnet` no está instalado en el entorno, por lo que no se realizaron compilaciones automáticas ni tests de CI en esta sesión.
- No se ejecutaron otros tests automatizados en el entorno actual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57aa5930b083339a8db30e21973015)