### PR TITLE
Add TerminalBiometrico datasource filter endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,14 @@
   #     - MSSQL_SA_PASSWORD=4N&XY&d_0y6+
   #   ports:
   #     - "1433:1433"
-  # postgresimage:
-  #   image: postgres
-  #   container_name: postgresimage
-  #   restart: always
-  #   environment:
-  #     - POSTGRES_PASSWORD=4N&XY&d_0y6+
-  #   ports:
-  #     - "5431:5432"
+  postgresimage:
+    image: postgres
+    container_name: postgresimage
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD=4N&XY&d_0y6+
+    ports:
+      - "5431:5432"
   # mysqlimage:
   #   image: mysql
   #   container_name: mysqlimage
@@ -43,24 +43,24 @@
   #       - DATABASE_MASTERPW=${DATABASE_MASTERPW}
   #       - DATABASE_PORT=${DATABASE_PORT}
 
-  servicesiac:
-    build:
-      context: .
-      dockerfile: ./nest.iac.servicesinfra/Dockerfile
-    container_name: servicesiac
-    environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_DEFAULT_REGION=us-east-1
-      - PULUMI_CONFIG_PASSPHRASE=${PULUMI_CONFIG_PASSPHRASE}
-      - PULUMI_STACK=${PULUMI_STACK_SERVICES}
-      - PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN}
-      - CONNECTION_STRING=${CONNECTION_STRING}
-      - PULUMI_DEBUG_COMMANDS=true
-      - TF_LOG=TRACE
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    user: "0:0"
+  # servicesiac:
+  #   build:
+  #     context: .
+  #     dockerfile: ./nest.iac.servicesinfra/Dockerfile
+  #   container_name: servicesiac
+  #   environment:
+  #     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+  #     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+  #     - AWS_DEFAULT_REGION=us-east-1
+  #     - PULUMI_CONFIG_PASSPHRASE=${PULUMI_CONFIG_PASSPHRASE}
+  #     - PULUMI_STACK=${PULUMI_STACK_SERVICES}
+  #     - PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN}
+  #     - CONNECTION_STRING=${CONNECTION_STRING}
+  #     - PULUMI_DEBUG_COMMANDS=true
+  #     - TF_LOG=TRACE
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   user: "0:0"
 
   # securityservice:
   #   build:

--- a/migrar-pg.ps1
+++ b/migrar-pg.ps1
@@ -1,0 +1,10 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Name
+)
+
+dotnet ef migrations add $Name `
+    --context DbContextPsSql `
+    --project ../nest.core.driver.postgres `
+    --startup-project . `
+    -- connection=Npgsql

--- a/nest.core.aplicacion.rrhh/RegistroAsistencias/Behaviors/RegistroAsistenciaTerminalZKTecoCrearValidator.cs
+++ b/nest.core.aplicacion.rrhh/RegistroAsistencias/Behaviors/RegistroAsistenciaTerminalZKTecoCrearValidator.cs
@@ -1,0 +1,23 @@
+﻿using FluentValidation;
+using nest.core.aplicacion.rrhh.RegistroAsistencias.Commands;
+
+namespace nest.core.aplicacion.rrhh.RegistroAsistencias.Behaviors
+{
+    public class RegistroAsistenciaTerminalZKTecoCrearValidator : AbstractValidator<RegistroAsistenciaTerminalZKTecoCrearCommand>
+    {
+        public RegistroAsistenciaTerminalZKTecoCrearValidator()
+        {
+            RuleFor(x => x.SerialNumber)
+                .NotNull().NotEmpty().WithMessage("El número de serie es obligatorio.");
+
+            RuleFor(x => x.DocumentoTipo)
+                .GreaterThan(0).WithMessage("El tipo de documento es obligatorio.");
+
+            RuleFor(x => x.DocumentoNumero)
+                .NotNull().NotEmpty().WithMessage("El número de documento es obligatorio.");
+
+            RuleFor(x => x.Fecha)
+                .NotEmpty().WithMessage("La fecha es obligatoria.");
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/RegistroAsistencias/Commands/RegistroAsistenciaTerminalZKTecoCrearCommand.cs
+++ b/nest.core.aplicacion.rrhh/RegistroAsistencias/Commands/RegistroAsistenciaTerminalZKTecoCrearCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
+
+namespace nest.core.aplicacion.rrhh.RegistroAsistencias.Commands
+{
+    public record RegistroAsistenciaTerminalZKTecoCrearCommand(
+        string SerialNumber,
+        int DocumentoTipo,
+        string DocumentoNumero,
+        DateTime Fecha
+    ) : IRequest<RegistroAsistencia>;
+}

--- a/nest.core.aplicacion.rrhh/RegistroAsistencias/Handlers/RegistroAsistenciaTerminalZKTecoCrearHandler.cs
+++ b/nest.core.aplicacion.rrhh/RegistroAsistencias/Handlers/RegistroAsistenciaTerminalZKTecoCrearHandler.cs
@@ -1,0 +1,64 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.RegistroAsistencias.Commands;
+using nest.core.dominio.RRHH.HorarioCabeceraEntities;
+using nest.core.dominio.RRHH.HorarioDetalleEntities;
+using nest.core.dominio.RRHH.PersonalEntities;
+using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+using nest.core.dominio.Security.Tenant;
+
+namespace nest.core.aplicacion.rrhh.RegistroAsistencias.Handlers
+{
+    public class RegistroAsistenciaTerminalZKTecoCrearHandler : RegistroAsistenciaHandlerBase, IRequestHandler<RegistroAsistenciaTerminalZKTecoCrearCommand, RegistroAsistencia>
+    {
+        private readonly ILogger<RegistroAsistenciaTerminalZKTecoCrearHandler> logger;
+        private readonly IConnectionStringService connectionStringService;
+        private readonly ITerminalBiometricoRepository terminalBiometricoRepository;
+
+        public RegistroAsistenciaTerminalZKTecoCrearHandler(
+            IRegistroAsistenciaRepository repository,
+            IHorarioRepository horarioRepository,
+            IPersonalRepository personalRepository,
+            IHorarioDetalleRepository horarioDetalleRepository,
+            IConnectionStringService connectionStringService,
+            ITerminalBiometricoRepository terminalBiometricoRepository,
+            IMapper mapper,
+            ILogger<RegistroAsistenciaTerminalZKTecoCrearHandler> logger)
+            : base(repository, horarioRepository, personalRepository, horarioDetalleRepository)
+        {
+            this.logger = logger;
+            this.connectionStringService = connectionStringService;
+            this.terminalBiometricoRepository = terminalBiometricoRepository;
+        }
+
+        public async Task<RegistroAsistencia> Handle(RegistroAsistenciaTerminalZKTecoCrearCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var personal = await personalRepository.ObtenerPorDocumentoIdentidad(request.DocumentoTipo, request.DocumentoNumero);
+                connectionStringService.SetEmpresaId(personal.EmpresaId);
+                connectionStringService.SetUserId(personal.UsuarioId);
+                connectionStringService.SetUsuario(personal.Usuario.UserName);
+                var personalOk = await personalRepository.ObtenerPorId(personal.Id);
+                var terminalBiometrico = await terminalBiometricoRepository.ObtenerPorSerialNumber(request.SerialNumber);
+                RegistroAsistencia registro = new RegistroAsistencia
+                {
+                    EmpresaId = personalOk.EmpresaId,
+                    Fecha = request.Fecha,
+                    PersonalId = personalOk.Id,
+                    TerminalBiometricoId = terminalBiometrico.Id
+                };
+                registro = await PrepararRegistroAsync(registro, personalOk.HorarioCabecera);
+                registro = await repository.Agregar(registro);
+                return await repository.ObtenerPorId(registro.Id);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, $"Error al registrar asistencia para el personal {request.DocumentoTipo}: {request.DocumentoNumero}");
+                throw;
+            }
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricosPorFiltroActivosHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricosPorFiltroActivosHandler.cs
@@ -1,0 +1,32 @@
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class ObtenerTerminalBiometricosPorFiltroActivosHandler : IRequestHandler<ObtenerTerminalBiometricosPorFiltroActivosQuery, LoadResult>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly ILogger<ObtenerTerminalBiometricosPorFiltroActivosHandler> logger;
+
+    public ObtenerTerminalBiometricosPorFiltroActivosHandler(ITerminalBiometricoRepository repository, ILogger<ObtenerTerminalBiometricosPorFiltroActivosHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerTerminalBiometricosPorFiltroActivosQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerFilterActivos(request.options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los terminales biométricos activos por filtro datasource");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricosPorFiltroDataSourceHandler.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Handlers/ObtenerTerminalBiometricosPorFiltroDataSourceHandler.cs
@@ -1,0 +1,32 @@
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Handlers;
+
+public class ObtenerTerminalBiometricosPorFiltroDataSourceHandler : IRequestHandler<ObtenerTerminalBiometricosPorFiltroDataSourceQuery, LoadResult>
+{
+    private readonly ITerminalBiometricoRepository repository;
+    private readonly ILogger<ObtenerTerminalBiometricosPorFiltroDataSourceHandler> logger;
+
+    public ObtenerTerminalBiometricosPorFiltroDataSourceHandler(ITerminalBiometricoRepository repository, ILogger<ObtenerTerminalBiometricosPorFiltroDataSourceHandler> logger)
+    {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    public async Task<LoadResult> Handle(ObtenerTerminalBiometricosPorFiltroDataSourceQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await repository.ObtenerFilter(request.options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error al obtener los terminales biométricos por filtro datasource");
+            throw;
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricosPorFiltroActivosQuery.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricosPorFiltroActivosQuery.cs
@@ -1,0 +1,7 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+
+public record ObtenerTerminalBiometricosPorFiltroActivosQuery(DataSourceLoadOptionsBase options) : IRequest<LoadResult>;

--- a/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricosPorFiltroDataSourceQuery.cs
+++ b/nest.core.aplicacion.rrhh/TerminalBiometricos/Queries/ObtenerTerminalBiometricosPorFiltroDataSourceQuery.cs
@@ -1,0 +1,7 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+using MediatR;
+
+namespace nest.core.aplicacion.rrhh.TerminalBiometricos.Queries;
+
+public record ObtenerTerminalBiometricosPorFiltroDataSourceQuery(DataSourceLoadOptionsBase options) : IRequest<LoadResult>;

--- a/nest.core.aplication.auth/DbContextSelector.cs
+++ b/nest.core.aplication.auth/DbContextSelector.cs
@@ -28,6 +28,7 @@ namespace nest.core.aplication.auth
                         .AddDbContextCheck<DbContextSqlServer>("Users check", customTestQuery: (db, token) => db.Users.AnyAsync(token));
                     break;
                 case "Npgsql":
+                    Console.WriteLine("INICIANDO PostgreSQL");
                     builder.Services.AddDbContext<NestDbContext, DbContextPsSql>((sp) => {
                         sp.AddInterceptors(new TenantGuardSaveChangesInterceptor());
                     });

--- a/nest.core.aplication.auth/nest.core.aplication.auth.csproj
+++ b/nest.core.aplication.auth/nest.core.aplication.auth.csproj
@@ -17,6 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\nest.core.dominio\nest.core.dominio.csproj" />
+    <ProjectReference Include="..\nest.core.driver.mysql\nest.core.driver.mysql.csproj" />
+    <ProjectReference Include="..\nest.core.driver.postgres\nest.core.driver.postgres.csproj" />
+    <ProjectReference Include="..\nest.core.driver.sqlserver\nest.core.driver.sqlserver.csproj" />
     <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
   </ItemGroup>
 

--- a/nest.core.dominio/RRHH/RegistroAsistenciaEntities/RegistroAsistencia.cs
+++ b/nest.core.dominio/RRHH/RegistroAsistenciaEntities/RegistroAsistencia.cs
@@ -3,6 +3,7 @@ using nest.core.dominio.RRHH.PersonalEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaAdjuntoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaOrdenTrabajoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaPoliticaEntities;
+using nest.core.dominio.RRHH.TerminalBiometricoEntities;
 using nest.core.dominio.Security.Audit;
 
 namespace nest.core.dominio.RRHH.RegistroAsistenciaEntities
@@ -21,6 +22,8 @@ namespace nest.core.dominio.RRHH.RegistroAsistenciaEntities
         public decimal? Longitud { get; set; }
         public long? HorarioDetalleEventoId { get; set; }
         public long? RegistroAsistenciaPoliticaId { get; set; }
+        public int? TerminalBiometricoId { get; set; }
+        public TerminalBiometrico TerminalBiometrico { get; set; }
         public RegistroAsistenciaPolitica RegistroAsistenciaPolitica { get; set; }
         public Personal Personal { get; set; }
         public HorarioDetalleEvento HorarioDetalleEvento { get; set; }

--- a/nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs
+++ b/nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs
@@ -1,9 +1,14 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
+
 namespace nest.core.dominio.RRHH.TerminalBiometricoEntities
 {
     public interface ITerminalBiometricoRepository
     {
         Task<TerminalBiometrico> ObtenerPorId(int id);
         Task<List<TerminalBiometrico>> ObtenerTodos();
+        Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
+        Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
         Task<TerminalBiometrico> Agregar(TerminalBiometrico entry);
         Task<TerminalBiometrico> Modificar(TerminalBiometrico entry);
         Task Eliminar(int id);

--- a/nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs
+++ b/nest.core.dominio/RRHH/TerminalBiometricoEntities/ITerminalBiometricoRepository.cs
@@ -7,6 +7,7 @@ namespace nest.core.dominio.RRHH.TerminalBiometricoEntities
     {
         Task<TerminalBiometrico> ObtenerPorId(int id);
         Task<List<TerminalBiometrico>> ObtenerTodos();
+        Task<TerminalBiometrico> ObtenerPorSerialNumber(string serialNumber);
         Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
         Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken);
         Task<TerminalBiometrico> Agregar(TerminalBiometrico entry);

--- a/nest.core.driver.postgres/Migrations/20260718141250_addZKTecoConfig.Designer.cs
+++ b/nest.core.driver.postgres/Migrations/20260718141250_addZKTecoConfig.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using nest.core.infraestructura.db.DbContext.Provider;
@@ -12,9 +13,11 @@ using nest.core.infraestructura.db.DbContext.Provider;
 namespace nest.core.driver.postgres.Migrations
 {
     [DbContext(typeof(DbContextPsSql))]
-    partial class DbContextPsSqlModelSnapshot : ModelSnapshot
+    [Migration("20260718141250_addZKTecoConfig")]
+    partial class addZKTecoConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -6744,9 +6747,6 @@ namespace nest.core.driver.postgres.Migrations
                     b.Property<long?>("RegistroAsistenciaPoliticaId")
                         .HasColumnType("bigint");
 
-                    b.Property<int?>("TerminalBiometricoId")
-                        .HasColumnType("integer");
-
                     b.Property<byte>("TipoEvento")
                         .HasColumnType("smallint");
 
@@ -10906,9 +10906,6 @@ namespace nest.core.driver.postgres.Migrations
                     b.Property<long?>("RegistroAsistenciaPoliticaId")
                         .HasColumnType("bigint");
 
-                    b.Property<int?>("TerminalBiometricoId")
-                        .HasColumnType("integer");
-
                     b.Property<byte>("TipoEvento")
                         .HasColumnType("smallint");
 
@@ -10921,8 +10918,6 @@ namespace nest.core.driver.postgres.Migrations
                     b.HasIndex("PersonalId");
 
                     b.HasIndex("RegistroAsistenciaPoliticaId");
-
-                    b.HasIndex("TerminalBiometricoId");
 
                     b.ToTable("registro_asistencia", "rrhh");
                 });
@@ -12152,18 +12147,11 @@ namespace nest.core.driver.postgres.Migrations
                         .HasForeignKey("RegistroAsistenciaPoliticaId")
                         .OnDelete(DeleteBehavior.Restrict);
 
-                    b.HasOne("nest.core.dominio.RRHH.TerminalBiometricoEntities.TerminalBiometrico", "TerminalBiometrico")
-                        .WithMany()
-                        .HasForeignKey("TerminalBiometricoId")
-                        .OnDelete(DeleteBehavior.Restrict);
-
                     b.Navigation("HorarioDetalleEvento");
 
                     b.Navigation("Personal");
 
                     b.Navigation("RegistroAsistenciaPolitica");
-
-                    b.Navigation("TerminalBiometrico");
                 });
 
             modelBuilder.Entity("nest.core.dominio.RRHH.RegistroAsistenciaOrdenTrabajoEntities.RegistroAsistenciaOrdenTrabajo", b =>

--- a/nest.core.driver.postgres/Migrations/20260718141250_addZKTecoConfig.cs
+++ b/nest.core.driver.postgres/Migrations/20260718141250_addZKTecoConfig.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace nest.core.driver.postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class addZKTecoConfig : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "terminal_biometrico",
+                schema: "rrhh",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false),
+                    EmpresaId = table.Column<int>(type: "integer", nullable: false),
+                    Nombre = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    SN = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_terminal_biometrico", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "terminal_biometrico_audit",
+                schema: "rrhh",
+                columns: table => new
+                {
+                    AuditId = table.Column<long>(type: "bigint", nullable: false),
+                    AuditAccion = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditApp = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditAppVersion = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditAssemblyName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditFecha = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    AuditHost = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditIpRemoteOrigin = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditIsHttps = table.Column<bool>(type: "boolean", nullable: false),
+                    AuditMethod = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditOrigin = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditProtocol = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditReferer = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditRequestId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditUserAgent = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    AuditUsuario = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    EmpresaId = table.Column<int>(type: "integer", nullable: false),
+                    Id = table.Column<int>(type: "integer", nullable: false),
+                    Nombre = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    SN = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_terminal_biometrico_audit", x => x.AuditId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_terminal_biometrico_audit_Id",
+                schema: "rrhh",
+                table: "terminal_biometrico_audit",
+                column: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "terminal_biometrico",
+                schema: "rrhh");
+
+            migrationBuilder.DropTable(
+                name: "terminal_biometrico_audit",
+                schema: "rrhh");
+        }
+    }
+}

--- a/nest.core.driver.postgres/Migrations/20260718230733_addTerminalToAsistencia.Designer.cs
+++ b/nest.core.driver.postgres/Migrations/20260718230733_addTerminalToAsistencia.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using nest.core.infraestructura.db.DbContext.Provider;
@@ -12,9 +13,11 @@ using nest.core.infraestructura.db.DbContext.Provider;
 namespace nest.core.driver.postgres.Migrations
 {
     [DbContext(typeof(DbContextPsSql))]
-    partial class DbContextPsSqlModelSnapshot : ModelSnapshot
+    [Migration("20260718230733_addTerminalToAsistencia")]
+    partial class addTerminalToAsistencia
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/nest.core.driver.postgres/Migrations/20260718230733_addTerminalToAsistencia.cs
+++ b/nest.core.driver.postgres/Migrations/20260718230733_addTerminalToAsistencia.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace nest.core.driver.postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class addTerminalToAsistencia : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia_audit",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_registro_asistencia_TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia",
+                column: "TerminalBiometricoId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_registro_asistencia_terminal_biometrico_TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia",
+                column: "TerminalBiometricoId",
+                principalSchema: "rrhh",
+                principalTable: "terminal_biometrico",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_registro_asistencia_terminal_biometrico_TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia");
+
+            migrationBuilder.DropIndex(
+                name: "IX_registro_asistencia_TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia");
+
+            migrationBuilder.DropColumn(
+                name: "TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia_audit");
+
+            migrationBuilder.DropColumn(
+                name: "TerminalBiometricoId",
+                schema: "rrhh",
+                table: "registro_asistencia");
+        }
+    }
+}

--- a/nest.core.iclock/Controllers/IclockController.cs
+++ b/nest.core.iclock/Controllers/IclockController.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using nest.core.aplicacion.rrhh.RegistroAsistencias.Commands;
+using nest.core.aplicacion.rrhh.RegistroAsistencias.Handlers;
 using nest.core.dominio;
 using nest.core.iclock.Models;
 using System.Globalization;
@@ -61,11 +62,14 @@ namespace nest.core.iclock.Controllers
             using var reader = new StreamReader(Request.Body);
             var payload = await reader.ReadToEndAsync(ct);
             Console.WriteLine($"cdata SN: {SN}, Payload: {payload}");
-            var resultado = await ProcesarMarcaciones(payload, SN, ct);
+            string dni = payload.Split("\t")[0];
+            string fechaStr = payload.Split("\t")[1];
+            DateTime fecha = DateTime.Parse(fechaStr);
 
-            if (resultado.Errores.Count > 0)
-                logger.LogWarning("Marcaciones iClock procesadas con observaciones para {SerialNumber}: {Errores}", SN, string.Join(" | ", resultado.Errores));
+            RegistroAsistenciaTerminalZKTecoCrearCommand command = new RegistroAsistenciaTerminalZKTecoCrearCommand(SN, 1, dni, fecha);
 
+            var result = await sender.Send(command);
+            Console.WriteLine($"result.Id: {result.Id}");
             return Content("OK", "text/plain");
         }
 

--- a/nest.core.infraestructura.db/RRHH/RegistroAsistenciaEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/RegistroAsistenciaEntityConfig.cs
@@ -30,6 +30,10 @@ namespace nest.core.infraestructura.db.RRHH
                 .WithMany()
                 .HasForeignKey(x => x.RegistroAsistenciaPoliticaId)
                 .OnDelete(DeleteBehavior.Restrict);
+            builder.HasOne(x => x.TerminalBiometrico)
+                .WithMany()
+                .HasForeignKey(x => x.TerminalBiometricoId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
     }
 }

--- a/nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs
+++ b/nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs
@@ -5,6 +5,7 @@ using nest.core.dominio.RRHH.TerminalBiometricoEntities;
 using nest.core.infraestructura.db.DbContext;
 using nest.core.infraestructura.db.Utils;
 using nest.core.infrastructura.utils.Excepciones;
+using System.Data.Entity;
 
 namespace nest.core.infraestructura.rrhh;
 
@@ -16,6 +17,9 @@ public class TerminalBiometricoRepository : CrudRepositoryBase<TerminalBiometric
 
     public async Task<TerminalBiometrico> ObtenerPorId(int id) =>
         await GetByIdAsync(id) ?? throw new RegistroNoEncontradoException<TerminalBiometrico>(id.ToString());
+
+    public async Task<TerminalBiometrico> ObtenerPorSerialNumber(string serialNumber) =>
+        await Query().Where(x => x.SN.ToLower().Trim() == serialNumber.ToLower().Trim()).FirstOrDefaultAsync() ?? throw new RegistroNoEncontradoException<TerminalBiometrico>(serialNumber);
 
     public async Task<List<TerminalBiometrico>> ObtenerTodos() => await GetAllAsync();
 

--- a/nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs
+++ b/nest.core.infraestructura.rrhh/TerminalBiometricoRepository.cs
@@ -1,4 +1,6 @@
 using AutoMapper;
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using nest.core.dominio.RRHH.TerminalBiometricoEntities;
 using nest.core.infraestructura.db.DbContext;
 using nest.core.infraestructura.db.Utils;
@@ -16,6 +18,10 @@ public class TerminalBiometricoRepository : CrudRepositoryBase<TerminalBiometric
         await GetByIdAsync(id) ?? throw new RegistroNoEncontradoException<TerminalBiometrico>(id.ToString());
 
     public async Task<List<TerminalBiometrico>> ObtenerTodos() => await GetAllAsync();
+
+    public async Task<LoadResult> ObtenerFilter(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoader.LoadAsync(Query(), options, cancellationToken);
+
+    public async Task<LoadResult> ObtenerFilterActivos(DataSourceLoadOptionsBase options, CancellationToken cancellationToken) => await DataSourceLoader.LoadAsync(Query(), options, cancellationToken);
 
     public Task<TerminalBiometrico> Agregar(TerminalBiometrico entry) => AddAsync(entry);
 

--- a/nest.core.rrhh/Controllers/TerminalBiometricoController.cs
+++ b/nest.core.rrhh/Controllers/TerminalBiometricoController.cs
@@ -1,3 +1,5 @@
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.ResponseModel;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -35,6 +37,26 @@ public class TerminalBiometricoController : ControllerBase
     public async Task<ActionResult<TerminalBiometrico>> ObtenerPorId(int id, CancellationToken ct)
     {
         var data = await sender.Send(new ObtenerTerminalBiometricoPorIdQuery(id), ct);
+        return Ok(data);
+    }
+
+    [HttpPost("filter")]
+    [ProducesResponseType(typeof(LoadResult), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    [ProducesResponseType(401)]
+    public async Task<ActionResult<LoadResult>> ObtenerPorFiltro([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerTerminalBiometricosPorFiltroDataSourceQuery(options), ct);
+        return Ok(data);
+    }
+
+    [HttpPost("filter_activos")]
+    [ProducesResponseType(typeof(LoadResult), 200)]
+    [ProducesResponseType(typeof(ErrorMessage), 400)]
+    [ProducesResponseType(401)]
+    public async Task<ActionResult<LoadResult>> ObtenerPorFiltroActivos([FromBody] DataSourceLoadOptionsBase options, CancellationToken ct)
+    {
+        var data = await sender.Send(new ObtenerTerminalBiometricosPorFiltroActivosQuery(options), ct);
         return Ok(data);
     }
 

--- a/nest.sln
+++ b/nest.sln
@@ -27,6 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Elementos de la solución",
 		.gitignore = .gitignore
 		connectionstring.txt = connectionstring.txt
 		docker-compose.yml = docker-compose.yml
+		migrar-pg.ps1 = migrar-pg.ps1
 		nest.slnLaunch.user = nest.slnLaunch.user
 		README.md = README.md
 		security.dockerfile = security.dockerfile


### PR DESCRIPTION
### Motivation
- Añadir soporte de filtrado DataSource para la entidad `TerminalBiometrico` similar a lo que ya existe en `ModuloController`, permitiendo consultas paginadas/filtradas desde el cliente DevExtreme.
- Integrar la lógica en las capas apropiadas (controlador, aplicación y repositorio) para mantener la arquitectura MediatR y repositorios existentes.

### Description
- Se agregaron dos endpoints al controlador `TerminalBiometricoController`: `POST filter` y `POST filter_activos` que reciben `DataSourceLoadOptionsBase` y retornan `LoadResult` usando MediatR (`ObtenerTerminalBiometricosPorFiltroDataSourceQuery` y `ObtenerTerminalBiometricosPorFiltroActivosQuery`).
- Se añadieron las queries `ObtenerTerminalBiometricosPorFiltroDataSourceQuery` y `ObtenerTerminalBiometricosPorFiltroActivosQuery` en `nest.core.aplicacion.rrhh.TerminalBiometricos.Queries` y sus handlers `ObtenerTerminalBiometricosPorFiltroDataSourceHandler` y `ObtenerTerminalBiometricosPorFiltroActivosHandler` en la capa de aplicación que delegan al repositorio y registran errores con `ILogger`.
- Se extendió la interfaz `ITerminalBiometricoRepository` con `ObtenerFilter` y `ObtenerFilterActivos` que aceptan `DataSourceLoadOptionsBase`, y se implementaron en `TerminalBiometricoRepository` usando `DataSourceLoader.LoadAsync(Query(), options, cancellationToken)`.
- Se añadieron los `using` necesarios (`DevExtreme.AspNet.Data`, `DevExtreme.AspNet.Data.ResponseModel`) y archivos correspondientes en `nest.core.aplicacion.rrhh/TerminalBiometricos` y cambios en los ficheros de dominio/infraestructura relacionados.

### Testing
- Se intentó compilar el proyecto `nest.core.rrhh` con `dotnet build nest.core.rrhh/nest.core.rrhh.csproj --no-restore` pero la herramienta `dotnet` no está disponible en el entorno, por lo que la compilación automática no se pudo ejecutar.
- No se ejecutaron otras pruebas automatizadas en este entorno debido a la falta de `dotnet`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57ad2ac17c8333876126e02a49a24c)