### PR TITLE
Agregar proyectos iClock (aplicación e infraestructura) y adaptar RecibirMarcaciones

### DIFF
--- a/nest.core.aplicacion.iclock/ConfigureServices.cs
+++ b/nest.core.aplicacion.iclock/ConfigureServices.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using nest.core.aplicacion.iclock.Marcaciones.Behaviors;
+using nest.core.aplicacion.utils.Behaviors;
+
+namespace nest.core.aplicacion.iclock
+{
+    public static class ConfigureServices
+    {
+        public static IServiceCollection ConfigureInfraestructura(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.ConfigureValidation(configuration);
+            return services;
+        }
+
+        private static void ConfigureValidation(this IServiceCollection services, IConfigurationManager configuration)
+        {
+            services.AddValidatorsFromAssembly(typeof(RecibirMarcacionesValidator).Assembly);
+            services.AddMediatR(cnf => {
+                cnf.RegisterServicesFromAssemblyContaining(typeof(RecibirMarcacionesValidator));
+                cnf.AddOpenBehavior(typeof(ValidationBehavior<,>));
+            });
+        }
+    }
+}

--- a/nest.core.aplicacion.iclock/Marcaciones/Behaviors/RecibirMarcacionesValidator.cs
+++ b/nest.core.aplicacion.iclock/Marcaciones/Behaviors/RecibirMarcacionesValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using nest.core.aplicacion.iclock.Marcaciones.Commands;
+
+namespace nest.core.aplicacion.iclock.Marcaciones.Behaviors
+{
+    public class RecibirMarcacionesValidator : AbstractValidator<RecibirMarcacionesCommand>
+    {
+        public RecibirMarcacionesValidator()
+        {
+            RuleFor(x => x.DocumentoTipo)
+                .GreaterThan(0).WithMessage("El tipo de documento es obligatorio.");
+
+            RuleFor(x => x.DocumentoNumero)
+                .NotNull().NotEmpty().WithMessage("El número de documento es obligatorio.");
+        }
+    }
+}

--- a/nest.core.aplicacion.iclock/Marcaciones/Commands/RecibirMarcacionesCommand.cs
+++ b/nest.core.aplicacion.iclock/Marcaciones/Commands/RecibirMarcacionesCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace nest.core.aplicacion.iclock.Marcaciones.Commands
+{
+    public record RecibirMarcacionesCommand(
+        int DocumentoTipo,
+        string DocumentoNumero
+    ) : IRequest<Unit>;
+}

--- a/nest.core.aplicacion.iclock/Marcaciones/Handlers/RecibirMarcacionesHandler.cs
+++ b/nest.core.aplicacion.iclock/Marcaciones/Handlers/RecibirMarcacionesHandler.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using nest.core.aplicacion.iclock.Marcaciones.Commands;
+
+namespace nest.core.aplicacion.iclock.Marcaciones.Handlers
+{
+    public class RecibirMarcacionesHandler : IRequestHandler<RecibirMarcacionesCommand, Unit>
+    {
+        public Task<Unit> Handle(RecibirMarcacionesCommand request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Unit.Value);
+        }
+    }
+}

--- a/nest.core.aplicacion.iclock/nest.core.aplicacion.iclock.csproj
+++ b/nest.core.aplicacion.iclock/nest.core.aplicacion.iclock.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="13.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.aplicacion.utils\nest.core.aplicacion.utils.csproj" />
+    <ProjectReference Include="..\nest.core.infraestructura.iclock\nest.core.infraestructura.iclock.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.core.iclock/Controllers/IclockController.cs
+++ b/nest.core.iclock/Controllers/IclockController.cs
@@ -1,7 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using nest.core.aplicacion.rrhh.RegistroAsistencias.Commands;
+using nest.core.aplicacion.iclock.Marcaciones.Commands;
 using nest.core.dominio;
 using nest.core.iclock.Models;
 using System.Globalization;
@@ -56,19 +56,11 @@ namespace nest.core.iclock.Controllers
         [Consumes("text/plain", "application/octet-stream", "application/x-www-form-urlencoded")]
         [ProducesResponseType(typeof(string), 200)]
         [ProducesResponseType(typeof(ErrorMessage), 400)]
-        public async Task<ActionResult<string>> RecibirMarcaciones([FromQuery] string SN, CancellationToken ct)
+        public async Task<ActionResult<string>> RecibirMarcaciones([FromQuery] int DocumentoTipo, [FromQuery] string DocumentoNumero, CancellationToken ct)
         {
-            using var reader = new StreamReader(Request.Body);
-            var payload = await reader.ReadToEndAsync(ct);
-            Console.WriteLine($"cdata SN: {SN}, Payload: {payload}");
-            string dni = payload.Split("\t")[0];
-            string fechaStr = payload.Split("\t")[1];
-            DateTime fecha = DateTime.Parse(fechaStr);
+            RecibirMarcacionesCommand command = new RecibirMarcacionesCommand(DocumentoTipo, DocumentoNumero);
 
-            RegistroAsistenciaTerminalZKTecoCrearCommand command = new RegistroAsistenciaTerminalZKTecoCrearCommand(SN, 1, dni, fecha);
-
-            var result = await sender.Send(command);
-            Console.WriteLine($"result.Id: {result.Id}");
+            await sender.Send(command, ct);
             return Content("OK", "text/plain");
         }
 

--- a/nest.core.iclock/Extensions/ConfigureServices.cs
+++ b/nest.core.iclock/Extensions/ConfigureServices.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
 using MediatR;
-using nest.core.aplicacion.rrhh;
-using nest.core.aplicacion.rrhh.RegistroAsistenciaOrdenTrabajos.Behaviors;
+using nest.core.aplicacion.iclock;
+using nest.core.aplicacion.iclock.Marcaciones.Behaviors;
 using nest.core.aplicacion.utils.Behaviors;
 using nest.core.dominio.Cache;
 using nest.core.infraestructura.db.Cache;
@@ -39,10 +39,10 @@ namespace nest.core.iclock.Extensions
 
         private static void ConfigureValidation(this IServiceCollection services)
         {
-            services.AddValidatorsFromAssembly(typeof(RegistroAsistenciaOrdenTrabajoCrearUsuarioActualValidator).Assembly);
+            services.AddValidatorsFromAssembly(typeof(RecibirMarcacionesValidator).Assembly);
             services.AddMediatR(cnf =>
             {
-                cnf.RegisterServicesFromAssemblyContaining(typeof(RegistroAsistenciaOrdenTrabajoCrearUsuarioActualValidator));
+                cnf.RegisterServicesFromAssemblyContaining(typeof(RecibirMarcacionesValidator));
                 cnf.AddOpenBehavior(typeof(ValidationBehavior<,>));
             });
         }

--- a/nest.core.iclock/nest.core.iclock.csproj
+++ b/nest.core.iclock/nest.core.iclock.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\nest.core.aplicacion.rrhh\nest.core.aplicacion.rrhh.csproj" />
+    <ProjectReference Include="..\nest.core.aplicacion.iclock\nest.core.aplicacion.iclock.csproj" />
     <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
   </ItemGroup>
 

--- a/nest.core.infraestructura.iclock/nest.core.infraestructura.iclock.csproj
+++ b/nest.core.infraestructura.iclock/nest.core.infraestructura.iclock.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nest.core.infraestructura.db\nest.core.infraestructura.db.csproj" />
+    <ProjectReference Include="..\nest.core.infrastructura.utils\nest.core.infrastructura.utils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/nest.sln
+++ b/nest.sln
@@ -127,6 +127,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.dataso
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.iclock", "nest.core.iclock\nest.core.iclock.csproj", "{FAFBD4F7-6F2B-B042-062C-0D06574A2E93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.aplicacion.iclock", "nest.core.aplicacion.iclock\nest.core.aplicacion.iclock.csproj", "{4DA3FA6D-D5CE-4B1E-9012-509D75E911A4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nest.core.infraestructura.iclock", "nest.core.infraestructura.iclock\nest.core.infraestructura.iclock.csproj", "{3066D5A9-6810-49F8-B93B-0F9A4B1D8A2E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -226,6 +230,10 @@ Global
 		{7E32C83F-BCBB-42E7-B32C-86CCA10101A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAFBD4F7-6F2B-B042-062C-0D06574A2E93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FAFBD4F7-6F2B-B042-062C-0D06574A2E93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DA3FA6D-D5CE-4B1E-9012-509D75E911A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DA3FA6D-D5CE-4B1E-9012-509D75E911A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3066D5A9-6810-49F8-B93B-0F9A4B1D8A2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3066D5A9-6810-49F8-B93B-0F9A4B1D8A2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -278,6 +286,8 @@ Global
 		{78548182-FF83-4E13-9F9F-7293805BC214} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
 		{7E32C83F-BCBB-42E7-B32C-86CCA10101A5} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
 		{FAFBD4F7-6F2B-B042-062C-0D06574A2E93} = {B8494947-0BD9-4763-BC5A-40667E95E294}
+		{4DA3FA6D-D5CE-4B1E-9012-509D75E911A4} = {0C7E7657-5A4E-423A-876C-85816FF210D6}
+		{3066D5A9-6810-49F8-B93B-0F9A4B1D8A2E} = {7598498A-9B3E-4E43-9743-73C8A19EE155}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {651F4B0C-740F-4ABF-8B23-D07A56743FFF}


### PR DESCRIPTION
### Motivation
- Separar la lógica de recepción de marcaciones en un proyecto de aplicación específico para iClock siguiendo la arquitectura del repo. 
- Proveer una implementación mínima que exponga los datos requeridos (`DocumentoTipo` y `DocumentoNumero`) para que `nest.core.iclock` invoque la capa de aplicación sin introducir lógica adicional.

### Description
- Se agrega el proyecto `nest.core.aplicacion.iclock` con el comando `RecibirMarcacionesCommand`, el `RecibirMarcacionesHandler` (implementación mínima) y el validador `RecibirMarcacionesValidator` usando `FluentValidation`.
- Se agrega el proyecto de infraestructura `nest.core.infraestructura.iclock` con referencias a las infraestructuras base del repositorio.
- Se actualiza `nest.core.iclock` para referenciar `nest.core.aplicacion.iclock` y se modifica `IclockController.RecibirMarcaciones` para recibir `DocumentoTipo` (`int`), `DocumentoNumero` (`string`) y `CancellationToken`, y para enviar el `RecibirMarcacionesCommand` a `MediatR` en lugar de parsear payload interno.
- Se actualizan los `csproj` y la solución para incluir los nuevos proyectos y la nueva referencia desde `nest.core.iclock`.

### Testing
- Se ejecutó `git diff --check` y no arrojó problemas.
- Se intentó ejecutar `dotnet --info` y herramientas `dotnet` desde el entorno pero no estaban disponibles, por lo que no se pudo ejecutar compilación/format o tests de .NET en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d0f47d8808333a5cced93c0d29a89)