### PR TITLE
Add PersonalCargoExterno CRUD support

### DIFF
--- a/nest.core.aplicacion.rrhh/ConfigureServices.cs
+++ b/nest.core.aplicacion.rrhh/ConfigureServices.cs
@@ -11,6 +11,7 @@ using nest.core.dominio.RRHH.HorarioCabeceraEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEventoEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
 using nest.core.dominio.RRHH.PersonalEstadoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaAdjuntoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
@@ -40,6 +41,7 @@ namespace nest.core.aplicacion.rrhh
             services.AddTransient<IHorarioDetalleRepository, HorarioDetalleRepository>();
             services.AddTransient<IHorarioDetalleEventoRepository, HorarioDetalleEventoRepository>();
             services.AddTransient<IPersonalRepository, PersonalRepository>();
+            services.AddTransient<IPersonalCargoExternoRepository, PersonalCargoExternoRepository>();
             services.AddTransient<IPersonalEstadoRepository, PersonalEstadoRepository>();
             services.AddTransient<IRegistroAsistenciaAdjuntoRepository, RegistroAsistenciaAdjuntoRepository>();
             services.AddTransient<IRegistroAsistenciaRepository, RegistroAsistenciaRepository>();

--- a/nest.core.aplicacion.rrhh/Mapper/AutoMapperProfiles.cs
+++ b/nest.core.aplicacion.rrhh/Mapper/AutoMapperProfiles.cs
@@ -6,6 +6,7 @@ using nest.core.aplicacion.rrhh.HorarioDetalleEventos.Commands;
 using nest.core.aplicacion.rrhh.HorarioDetalles.Commands;
 using nest.core.aplicacion.rrhh.Horarios.Commands;
 using nest.core.aplicacion.rrhh.Personales.Commands;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
 using nest.core.aplicacion.rrhh.PersonalEstados.Commands;
 using nest.core.aplicacion.rrhh.RegistroAsistenciaAdjuntos.Commands;
 using nest.core.aplicacion.rrhh.RegistroAsistenciaOrdenTrabajos.Commands;
@@ -20,6 +21,7 @@ using nest.core.dominio.RRHH.HorarioCabeceraEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEventoEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
 using nest.core.dominio.RRHH.PersonalEstadoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaAdjuntoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
@@ -40,6 +42,8 @@ namespace nest.core.aplicacion.rrhh.Mapper
             CreateMap<HorarioModificarCommand, HorarioCabecera>();
             CreateMap<PersonalCrearCommand, Personal>();
             CreateMap<PersonalModificarCommand, Personal>();
+            CreateMap<PersonalCargoExternoCrearCommand, PersonalCargoExterno>();
+            CreateMap<PersonalCargoExternoModificarCommand, PersonalCargoExterno>();
             CreateMap<HorarioDetalleEventoCrearCommand, HorarioDetalleEvento>();
             CreateMap<HorarioDetalleEventoModificarCommand, HorarioDetalleEvento>();
             CreateMap<HorarioDetalleCrearCommand, HorarioDetalle>();
@@ -95,6 +99,9 @@ namespace nest.core.aplicacion.rrhh.Mapper
                 .ForMember(dest => dest.Usuario, opt => opt.Ignore())
                 .ForMember(dest => dest.OrdenTrabajoHorarios, opt => opt.Ignore());
             CreateMap<PersonalEstado, PersonalEstado>();
+            CreateMap<PersonalCargoExterno, PersonalCargoExterno>()
+                .ForMember(dest => dest.Personal, opt => opt.Ignore())
+                .ForMember(dest => dest.Cargo, opt => opt.Ignore());
             CreateMap<RegistroAsistenciaAdjunto, RegistroAsistenciaAdjunto>()
                 .ForMember(dest => dest.RegistroAsistencia, opt => opt.Ignore())
                 .ForMember(dest => dest.Adjunto, opt => opt.Ignore());

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoCrearValidator.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoCrearValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Behaviors;
+
+public class PersonalCargoExternoCrearValidator : AbstractValidator<PersonalCargoExternoCrearCommand>
+{
+    public PersonalCargoExternoCrearValidator()
+    {
+        Include(new PersonalCargoExternoGenericValidator<PersonalCargoExternoCrearCommand>());
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoEliminarValidator.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoEliminarValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Behaviors;
+
+public class PersonalCargoExternoEliminarValidator : AbstractValidator<PersonalCargoExternoEliminarCommand>
+{
+    public PersonalCargoExternoEliminarValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0).WithMessage("El identificador es obligatorio.");
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoGenericValidator.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoGenericValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Behaviors
+{
+    public class PersonalCargoExternoGenericValidator<TCommand> : AbstractValidator<TCommand>
+        where TCommand : IPersonalCargoExternoGenericCommand
+    {
+        public PersonalCargoExternoGenericValidator()
+        {
+            RuleFor(x => x.EmpresaId).GreaterThan(0).WithMessage("La empresa es obligatoria.");
+            RuleFor(x => x.PersonalId).GreaterThan(0).WithMessage("El personal es obligatorio.");
+            RuleFor(x => x.CargoId).GreaterThan(0).WithMessage("El cargo es obligatorio.");
+        }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoModificarValidator.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Behaviors/PersonalCargoExternoModificarValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Behaviors;
+
+public class PersonalCargoExternoModificarValidator : AbstractValidator<PersonalCargoExternoModificarCommand>
+{
+    public PersonalCargoExternoModificarValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0).WithMessage("El identificador es obligatorio.");
+        Include(new PersonalCargoExternoGenericValidator<PersonalCargoExternoModificarCommand>());
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/IPersonalCargoExternoGenericCommand.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/IPersonalCargoExternoGenericCommand.cs
@@ -1,0 +1,11 @@
+using nest.core.aplicacion.utils.Commands;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands
+{
+    public interface IPersonalCargoExternoGenericCommand : ICommandBase
+    {
+        int EmpresaId { get; }
+        int PersonalId { get; }
+        int CargoId { get; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/PersonalCargoExternoCrearCommand.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/PersonalCargoExternoCrearCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+public record PersonalCargoExternoCrearCommand(
+    int EmpresaId,
+    int PersonalId,
+    int CargoId
+) : IRequest<PersonalCargoExterno>, IPersonalCargoExternoGenericCommand;

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/PersonalCargoExternoEliminarCommand.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/PersonalCargoExternoEliminarCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.aplicacion.utils.Commands;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+public record PersonalCargoExternoEliminarCommand(long Id) : IRequest<Unit>, ICommandBase;

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/PersonalCargoExternoModificarCommand.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Commands/PersonalCargoExternoModificarCommand.cs
@@ -1,0 +1,11 @@
+using MediatR;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+
+public record PersonalCargoExternoModificarCommand(
+    long Id,
+    int EmpresaId,
+    int PersonalId,
+    int CargoId
+) : IRequest<PersonalCargoExterno>, IPersonalCargoExternoGenericCommand;

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternoPorIdHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternoPorIdHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class ObtenerPersonalCargoExternoPorIdHandler : IRequestHandler<ObtenerPersonalCargoExternoPorIdQuery, PersonalCargoExterno>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly ILogger<ObtenerPersonalCargoExternoPorIdHandler> logger;
+
+    public ObtenerPersonalCargoExternoPorIdHandler(IPersonalCargoExternoRepository repository, ILogger<ObtenerPersonalCargoExternoPorIdHandler> logger)
+    { this.repository = repository; this.logger = logger; }
+
+    public async Task<PersonalCargoExterno> Handle(ObtenerPersonalCargoExternoPorIdQuery request, CancellationToken cancellationToken)
+    {
+        try { return await repository.ObtenerPorId(request.Id); }
+        catch (Exception ex) { logger.LogError(ex, "Error al obtener el cargo externo del personal {Id}", request.Id); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternosHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternosHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class ObtenerPersonalCargoExternosHandler : IRequestHandler<ObtenerPersonalCargoExternosQuery, List<PersonalCargoExterno>>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly ILogger<ObtenerPersonalCargoExternosHandler> logger;
+
+    public ObtenerPersonalCargoExternosHandler(IPersonalCargoExternoRepository repository, ILogger<ObtenerPersonalCargoExternosHandler> logger)
+    { this.repository = repository; this.logger = logger; }
+
+    public async Task<List<PersonalCargoExterno>> Handle(ObtenerPersonalCargoExternosQuery request, CancellationToken cancellationToken)
+    {
+        try { return await repository.ObtenerTodos(); }
+        catch (Exception ex) { logger.LogError(ex, "Error al obtener los cargos externos del personal"); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternosPorCargoHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternosPorCargoHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class ObtenerPersonalCargoExternosPorCargoHandler : IRequestHandler<ObtenerPersonalCargoExternosPorCargoQuery, List<PersonalCargoExterno>>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly ILogger<ObtenerPersonalCargoExternosPorCargoHandler> logger;
+
+    public ObtenerPersonalCargoExternosPorCargoHandler(IPersonalCargoExternoRepository repository, ILogger<ObtenerPersonalCargoExternosPorCargoHandler> logger)
+    { this.repository = repository; this.logger = logger; }
+
+    public async Task<List<PersonalCargoExterno>> Handle(ObtenerPersonalCargoExternosPorCargoQuery request, CancellationToken cancellationToken)
+    {
+        try { return await repository.ObtenerPorCargo(request.CargoId); }
+        catch (Exception ex) { logger.LogError(ex, "Error al obtener los cargos externos por cargo {CargoId}", request.CargoId); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternosPorPersonalHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/ObtenerPersonalCargoExternosPorPersonalHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class ObtenerPersonalCargoExternosPorPersonalHandler : IRequestHandler<ObtenerPersonalCargoExternosPorPersonalQuery, List<PersonalCargoExterno>>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly ILogger<ObtenerPersonalCargoExternosPorPersonalHandler> logger;
+
+    public ObtenerPersonalCargoExternosPorPersonalHandler(IPersonalCargoExternoRepository repository, ILogger<ObtenerPersonalCargoExternosPorPersonalHandler> logger)
+    { this.repository = repository; this.logger = logger; }
+
+    public async Task<List<PersonalCargoExterno>> Handle(ObtenerPersonalCargoExternosPorPersonalQuery request, CancellationToken cancellationToken)
+    {
+        try { return await repository.ObtenerPorPersonal(request.PersonalId); }
+        catch (Exception ex) { logger.LogError(ex, "Error al obtener los cargos externos del personal {PersonalId}", request.PersonalId); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/PersonalCargoExternoCrearHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/PersonalCargoExternoCrearHandler.cs
@@ -1,0 +1,23 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class PersonalCargoExternoCrearHandler : IRequestHandler<PersonalCargoExternoCrearCommand, PersonalCargoExterno>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly IMapper mapper;
+    private readonly ILogger<PersonalCargoExternoCrearHandler> logger;
+
+    public PersonalCargoExternoCrearHandler(IPersonalCargoExternoRepository repository, IMapper mapper, ILogger<PersonalCargoExternoCrearHandler> logger)
+    { this.repository = repository; this.mapper = mapper; this.logger = logger; }
+
+    public async Task<PersonalCargoExterno> Handle(PersonalCargoExternoCrearCommand request, CancellationToken cancellationToken)
+    {
+        try { return await repository.Agregar(mapper.Map<PersonalCargoExterno>(request)); }
+        catch (Exception ex) { logger.LogError(ex, "Error al crear el cargo externo del personal {PersonalId}", request.PersonalId); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/PersonalCargoExternoEliminarHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/PersonalCargoExternoEliminarHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class PersonalCargoExternoEliminarHandler : IRequestHandler<PersonalCargoExternoEliminarCommand, Unit>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly ILogger<PersonalCargoExternoEliminarHandler> logger;
+
+    public PersonalCargoExternoEliminarHandler(IPersonalCargoExternoRepository repository, ILogger<PersonalCargoExternoEliminarHandler> logger)
+    { this.repository = repository; this.logger = logger; }
+
+    public async Task<Unit> Handle(PersonalCargoExternoEliminarCommand request, CancellationToken cancellationToken)
+    {
+        try { await repository.Eliminar(request.Id); return Unit.Value; }
+        catch (Exception ex) { logger.LogError(ex, "Error al eliminar el cargo externo del personal {Id}", request.Id); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/PersonalCargoExternoModificarHandler.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Handlers/PersonalCargoExternoModificarHandler.cs
@@ -1,0 +1,23 @@
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Handlers;
+
+public class PersonalCargoExternoModificarHandler : IRequestHandler<PersonalCargoExternoModificarCommand, PersonalCargoExterno>
+{
+    private readonly IPersonalCargoExternoRepository repository;
+    private readonly IMapper mapper;
+    private readonly ILogger<PersonalCargoExternoModificarHandler> logger;
+
+    public PersonalCargoExternoModificarHandler(IPersonalCargoExternoRepository repository, IMapper mapper, ILogger<PersonalCargoExternoModificarHandler> logger)
+    { this.repository = repository; this.mapper = mapper; this.logger = logger; }
+
+    public async Task<PersonalCargoExterno> Handle(PersonalCargoExternoModificarCommand request, CancellationToken cancellationToken)
+    {
+        try { return await repository.Modificar(mapper.Map<PersonalCargoExterno>(request)); }
+        catch (Exception ex) { logger.LogError(ex, "Error al modificar el cargo externo del personal {Id}", request.Id); throw; }
+    }
+}

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternoPorIdQuery.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternoPorIdQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+
+public record ObtenerPersonalCargoExternoPorIdQuery(long Id) : IRequest<PersonalCargoExterno>;

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternosPorCargoQuery.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternosPorCargoQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+
+public record ObtenerPersonalCargoExternosPorCargoQuery(int CargoId) : IRequest<List<PersonalCargoExterno>>;

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternosPorPersonalQuery.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternosPorPersonalQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+
+public record ObtenerPersonalCargoExternosPorPersonalQuery(int PersonalId) : IRequest<List<PersonalCargoExterno>>;

--- a/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternosQuery.cs
+++ b/nest.core.aplicacion.rrhh/PersonalCargoExternos/Queries/ObtenerPersonalCargoExternosQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+
+public record ObtenerPersonalCargoExternosQuery() : IRequest<List<PersonalCargoExterno>>;

--- a/nest.core.dominio/RRHH/PersonalCargoExternoEntities/IPersonalCargoExternoRepository.cs
+++ b/nest.core.dominio/RRHH/PersonalCargoExternoEntities/IPersonalCargoExternoRepository.cs
@@ -1,0 +1,13 @@
+﻿namespace nest.core.dominio.RRHH.PersonalCargoExternoEntities
+{
+    public interface IPersonalCargoExternoRepository
+    {
+        Task<PersonalCargoExterno> ObtenerPorId(long id);
+        Task<List<PersonalCargoExterno>> ObtenerTodos();
+        Task<List<PersonalCargoExterno>> ObtenerPorPersonal(int personalId);
+        Task<List<PersonalCargoExterno>> ObtenerPorCargo(int cargoId);
+        Task<PersonalCargoExterno> Agregar(PersonalCargoExterno entidad);
+        Task<PersonalCargoExterno> Modificar(PersonalCargoExterno entidad);
+        Task Eliminar(long id);
+    }
+}

--- a/nest.core.infraestructura.db/DbContext/RRHHDbContext.cs
+++ b/nest.core.infraestructura.db/DbContext/RRHHDbContext.cs
@@ -7,6 +7,7 @@ using nest.core.dominio.RRHH.HorarioCabeceraEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEntities;
 using nest.core.dominio.RRHH.HorarioDetalleEventoEntities;
 using nest.core.dominio.RRHH.PersonalEntities;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
 using nest.core.dominio.RRHH.PersonalEstadoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaAdjuntoEntities;
 using nest.core.dominio.RRHH.RegistroAsistenciaEntities;
@@ -25,6 +26,7 @@ namespace nest.core.infraestructura.db.DbContext
         public DbSet<HorarioDetalle> HorarioDetalles { get; set; }
         public DbSet<HorarioDetalleEvento> HorarioDetalleEventos { get; set; }
         public DbSet<Personal> Personales { get; set; }
+        public DbSet<PersonalCargoExterno> PersonalCargoExterno { get; set; }
         public DbSet<PersonalEstado> PersonalEstado { get; set; }
         public DbSet<RegistroAsistencia> RegistroAsistencia { get; set; }
         public DbSet<RegistroAsistenciaPolitica> RegistroAsistenciaPolitica { get; set; }
@@ -39,6 +41,7 @@ namespace nest.core.infraestructura.db.DbContext
             modelBuilder.Entity<HorarioDetalle>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);
             modelBuilder.Entity<HorarioDetalleEvento>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);
             modelBuilder.Entity<Personal>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);
+            modelBuilder.Entity<PersonalCargoExterno>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);
             modelBuilder.Entity<RegistroAsistencia>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);
             modelBuilder.Entity<RegistroAsistenciaPolitica>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);
             modelBuilder.Entity<RegistroAsistenciaOrdenTrabajo>().HasQueryFilter(x => x.EmpresaId == this.EmpresaId);

--- a/nest.core.infraestructura.db/RRHH/PersonalCargoExternoEntityConfig.cs
+++ b/nest.core.infraestructura.db/RRHH/PersonalCargoExternoEntityConfig.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.infraestructura.db.RRHH
+{
+    public class PersonalCargoExternoEntityConfig : IEntityTypeConfiguration<PersonalCargoExterno>
+    {
+        public void Configure(EntityTypeBuilder<PersonalCargoExterno> builder)
+        {
+            builder.ToTable("personal_cargo_externo", "rrhh");
+            builder.HasKey(x => x.Id);
+            builder.HasIndex(x => x.EmpresaId);
+            builder.HasIndex(x => new { x.PersonalId, x.CargoId }).IsUnique();
+            builder.Property(x => x.Id)
+                .ValueGeneratedNever()
+                .HasValueGenerator<GenericValueGenerator<long>>();
+            builder.HasOne(x => x.Personal)
+                .WithMany()
+                .HasForeignKey(x => x.PersonalId)
+                .OnDelete(DeleteBehavior.Restrict);
+            builder.HasOne(x => x.Cargo)
+                .WithMany()
+                .HasForeignKey(x => x.CargoId)
+                .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/nest.core.infraestructura.rrhh/PersonalCargoExternoRepository.cs
+++ b/nest.core.infraestructura.rrhh/PersonalCargoExternoRepository.cs
@@ -1,0 +1,30 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+using nest.core.infraestructura.db.DbContext;
+using nest.core.infraestructura.db.Utils;
+
+namespace nest.core.infraestructura.rrhh
+{
+    public class PersonalCargoExternoRepository : CrudRepositoryBase<PersonalCargoExterno, long>, IPersonalCargoExternoRepository
+    {
+        private readonly NestDbContext context;
+
+        public PersonalCargoExternoRepository(NestDbContext context, IMapper mapper) : base(context, mapper)
+        {
+            this.context = context;
+        }
+
+        public async Task<PersonalCargoExterno> ObtenerPorId(long id) => await GetByIdAsync(id);
+        public async Task<List<PersonalCargoExterno>> ObtenerTodos() => await GetAllAsync();
+        public async Task<List<PersonalCargoExterno>> ObtenerPorPersonal(int personalId) => await context.Set<PersonalCargoExterno>().Where(x => x.PersonalId == personalId).ToListAsync();
+        public async Task<List<PersonalCargoExterno>> ObtenerPorCargo(int cargoId) => await context.Set<PersonalCargoExterno>().Where(x => x.CargoId == cargoId).ToListAsync();
+        public Task<PersonalCargoExterno> Agregar(PersonalCargoExterno entry) => AddAsync(entry);
+        public async Task<PersonalCargoExterno> Modificar(PersonalCargoExterno entry)
+        {
+            var response = await UpdateAsync(entry);
+            return await ObtenerPorId(response.Id);
+        }
+        public Task Eliminar(long id) => DeleteAsync(id);
+    }
+}

--- a/nest.core.rrhh/Controllers/PersonalCargoExternoController.cs
+++ b/nest.core.rrhh/Controllers/PersonalCargoExternoController.cs
@@ -1,0 +1,86 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Commands;
+using nest.core.aplicacion.rrhh.PersonalCargoExternos.Queries;
+using nest.core.dominio;
+using nest.core.dominio.RRHH.PersonalCargoExternoEntities;
+
+namespace nest.core.rrhh.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class PersonalCargoExternoController : ControllerBase
+    {
+        private readonly ISender sender;
+
+        public PersonalCargoExternoController(ISender sender)
+        {
+            this.sender = sender;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(List<PersonalCargoExterno>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<PersonalCargoExterno>>> ObtenerTodos(CancellationToken ct)
+        {
+            var data = await sender.Send(new ObtenerPersonalCargoExternosQuery(), ct);
+            return Ok(data);
+        }
+
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(PersonalCargoExterno), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<PersonalCargoExterno>> ObtenerPorId(long id, CancellationToken ct)
+        {
+            var data = await sender.Send(new ObtenerPersonalCargoExternoPorIdQuery(id), ct);
+            return Ok(data);
+        }
+
+        [HttpGet("personal/{personalId}")]
+        [ProducesResponseType(typeof(List<PersonalCargoExterno>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<PersonalCargoExterno>>> ObtenerPorPersonal(int personalId, CancellationToken ct)
+        {
+            var data = await sender.Send(new ObtenerPersonalCargoExternosPorPersonalQuery(personalId), ct);
+            return Ok(data);
+        }
+
+        [HttpGet("cargo/{cargoId}")]
+        [ProducesResponseType(typeof(List<PersonalCargoExterno>), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<List<PersonalCargoExterno>>> ObtenerPorCargo(int cargoId, CancellationToken ct)
+        {
+            var data = await sender.Send(new ObtenerPersonalCargoExternosPorCargoQuery(cargoId), ct);
+            return Ok(data);
+        }
+
+        [HttpPost]
+        [ProducesResponseType(typeof(PersonalCargoExterno), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<PersonalCargoExterno>> Agregar([FromBody] PersonalCargoExternoCrearCommand command, CancellationToken ct)
+        {
+            var data = await sender.Send(command, ct);
+            return Ok(data);
+        }
+
+        [HttpPut("{id}")]
+        [ProducesResponseType(typeof(PersonalCargoExterno), 200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult<PersonalCargoExterno>> Modificar(long id, [FromBody] PersonalCargoExternoModificarCommand command, CancellationToken ct)
+        {
+            var data = await sender.Send(command with { Id = id }, ct);
+            return Ok(data);
+        }
+
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(typeof(ErrorMessage), 400)]
+        public async Task<ActionResult> Eliminar(long id, CancellationToken ct)
+        {
+            await sender.Send(new PersonalCargoExternoEliminarCommand(id), ct);
+            return Ok();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Añadir soporte completo CRUD para la entidad `PersonalCargoExterno` en la capa de dominio, infraestructura, aplicación y API para poder gestionar cargos externos asignados al personal.
- Respetar los patrones existentes del proyecto (`CrudRepositoryBase`, MediatR handlers/commands/queries, FluentValidation, AutoMapper y DI).

### Description

- Se añadió la interfaz de repositorio `IPersonalCargoExternoRepository` y su implementación `PersonalCargoExternoRepository` basada en `CrudRepositoryBase` con métodos para obtener por id, todos, por personal, por cargo, agregar, modificar y eliminar.
- Se registró la entidad en EF Core: creada la configuración `PersonalCargoExternoEntityConfig` (tabla `rrhh.personal_cargo_externo`, índices, llave, generador de id y relaciones con `Personal` y `Cargo`) y agregado `DbSet<PersonalCargoExterno>` y filtro por `EmpresaId` en el contexto RRHH.
- Se implementó la capa de aplicación completa: commands, queries, handlers y validators bajo `nest.core.aplicacion.rrhh/PersonalCargoExternos`, además de mappings de AutoMapper para comandos y entidad y registro del repositorio en DI (`ConfigureInfraestructura`).
- Se añadió el controlador `PersonalCargoExternoController` con endpoints REST `GET`, `GET/{id}`, `GET/personal/{personalId}`, `GET/cargo/{cargoId}`, `POST`, `PUT/{id}` y `DELETE/{id}`.

### Testing

- Ejecutado `git diff --check` para validar formato y problemas triviales: éxito.
- Intentado `dotnet build nest.core.rrhh/nest.core.rrhh.csproj --no-restore` pero no se pudo ejecutar porque `dotnet` no está instalado en el entorno, por lo que no se realizó compilación automática aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f6e19509c833392006a8bf879b069)